### PR TITLE
chore: upgrade lint packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-shamefully-hoist = true
+# registry = https://registry.npmmirror.com

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,22 +1,3 @@
-import config from "@kriac/commitlint-config";
+import config from "@kriac/lint-kit/commitlint";
 
-export default config({
-  scopes: [
-    {
-      name: "kit: 聚合配置",
-      value: "kit",
-    },
-    {
-      name: "commitlint: 提交配置",
-      value: "commitlint",
-    },
-    {
-      name: "eslint: 代码配置",
-      value: "eslint",
-    },
-    {
-      name: "stylelint: 样式配置",
-      value: "stylelint",
-    },
-  ],
-});
+export default config();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-import config from "@kriac/eslint-config";
+import config from "@kriac/lint-kit/eslint";
 
 export default config({
   ignores: ["**/cache"],

--- a/package.json
+++ b/package.json
@@ -23,9 +23,7 @@
     "release:commit": "pnpm build:commit && pnpm -F @kriac/commitlint-config release"
   },
   "devDependencies": {
-    "@kriac/commitlint-config": "workspace:*",
-    "@kriac/eslint-config": "workspace:*",
-    "@kriac/stylelint-config": "workspace:*",
+    "@kriac/lint-kit": "workspace:*",
     "commitlint": "20.3.0",
     "czg": "1.13.0",
     "eslint": "9.39.4",

--- a/packages/commitlint/package.json
+++ b/packages/commitlint/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "vue-tsc -b --noEmit",
     "build": "tsdown",
-    "release": "npm publish --access public"
+    "release": "pnpm publish --access public"
   },
   "peerDependencies": {
     "czg": ">=1.0.0"

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "lint": "vue-tsc -b --noEmit",
     "build": "tsdown",
-    "release": "npm publish --access public"
+    "release": "pnpm publish --access public"
   },
   "peerDependencies": {
     "eslint": ">=9.0.0"
@@ -25,9 +25,9 @@
   "dependencies": {
     "@eslint/js": "9.39.4",
     "eslint-config-prettier": "10.1.8",
-    "eslint-plugin-perfectionist": "5.9.1",
-    "eslint-plugin-vue": "10.9.2",
-    "typescript-eslint": "8.61.1",
+    "eslint-plugin-perfectionist": "5.10.1",
+    "eslint-plugin-vue": "10.10.0",
+    "typescript-eslint": "8.66.0",
     "vue-eslint-parser": "10.4.0"
   },
   "devDependencies": {

--- a/packages/lint-kit/package.json
+++ b/packages/lint-kit/package.json
@@ -17,7 +17,10 @@
   "scripts": {
     "lint": "vue-tsc -b --noEmit",
     "build": "tsdown",
-    "release": "npm publish --access public"
+    "release": "pnpm publish --access public"
+  },
+  "engines": {
+    "node": "^22.12.0 || >=24.0.0"
   },
   "peerDependencies": {
     "czg": "^1.0.0",
@@ -25,13 +28,9 @@
     "stylelint": "^17.0.0"
   },
   "dependencies": {
-    "@kriac/commitlint-config": "0.7.0",
-    "@kriac/eslint-config": "0.9.0",
-    "@kriac/stylelint-config": "0.7.0",
-    "stylelint-config-recess-order": "7.7.0",
-    "stylelint-config-recommended-vue": "1.6.1",
-    "stylelint-config-standard-scss": "17.0.0",
-    "stylelint-order": "8.1.1"
+    "@kriac/commitlint-config": "workspace:*",
+    "@kriac/eslint-config": "workspace:*",
+    "@kriac/stylelint-config": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "25.6.0",

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -17,15 +17,15 @@
   "scripts": {
     "lint": "vue-tsc -b --noEmit",
     "build": "tsdown",
-    "release": "npm publish --access public"
+    "release": "pnpm publish --access public"
   },
   "peerDependencies": {
     "stylelint": ">=17.0.0"
   },
   "dependencies": {
-    "postcss-html": "1.8.1",
+    "postcss-html": "2.0.0",
     "stylelint-config-recess-order": "7.7.0",
-    "stylelint-config-recommended-vue": "1.6.1",
+    "stylelint-config-recommended-vue": "2.0.0",
     "stylelint-config-standard-scss": "17.0.0",
     "stylelint-order": "8.1.1"
   },

--- a/packages/stylelint/src/index.ts
+++ b/packages/stylelint/src/index.ts
@@ -1,18 +1,20 @@
-import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
 
-const require = createRequire(import.meta.url);
+const resolveModule = (specifier: string) => {
+  return fileURLToPath(import.meta.resolve(specifier));
+};
 
 export default {
   extends: [
-    "stylelint-config-standard-scss",
-    "stylelint-config-recommended-vue",
-    "stylelint-config-recess-order",
+    resolveModule("stylelint-config-standard-scss"),
+    resolveModule("stylelint-config-recommended-vue"),
+    resolveModule("stylelint-config-recess-order"),
   ],
-  plugins: ["stylelint-order"],
+  plugins: [resolveModule("stylelint-order")],
   overrides: [
     {
       files: ["**/*.html", "**/*.vue"],
-      customSyntax: require.resolve("postcss-html"),
+      customSyntax: resolveModule("postcss-html"),
     },
   ],
   rules: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,15 +7,9 @@ settings:
 importers:
   .:
     devDependencies:
-      "@kriac/commitlint-config":
+      "@kriac/lint-kit":
         specifier: workspace:*
-        version: link:packages/commitlint
-      "@kriac/eslint-config":
-        specifier: workspace:*
-        version: link:packages/eslint
-      "@kriac/stylelint-config":
-        specifier: workspace:*
-        version: link:packages/stylelint
+        version: link:packages/lint-kit
       commitlint:
         specifier: 20.3.0
         version: 20.3.0(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@5.8.2)
@@ -61,7 +55,7 @@ importers:
     devDependencies:
       vitepress:
         specifier: 1.6.4
-        version: 1.6.4(@algolia/client-search@5.55.0)(@types/node@25.6.0)(postcss@8.5.15)(sass@1.101.0)(search-insights@2.17.3)(typescript@5.8.2)
+        version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@25.6.0)(postcss@8.5.26)(sass@1.78.0)(search-insights@2.17.3)(typescript@5.8.2)
       vue:
         specifier: 3.5.13
         version: 3.5.13(typescript@5.8.2)
@@ -94,14 +88,14 @@ importers:
         specifier: 10.1.8
         version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-perfectionist:
-        specifier: 5.9.1
-        version: 5.9.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+        specifier: 5.10.1
+        version: 5.10.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
       eslint-plugin-vue:
-        specifier: 10.9.2
-        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
+        specifier: 10.10.0
+        version: 10.10.0(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
       typescript-eslint:
-        specifier: 8.61.1
-        version: 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+        specifier: 8.66.0
+        version: 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
       vue-eslint-parser:
         specifier: 10.4.0
         version: 10.4.0(eslint@9.39.4(jiti@2.6.1))
@@ -119,14 +113,14 @@ importers:
   packages/lint-kit:
     dependencies:
       "@kriac/commitlint-config":
-        specifier: 0.7.0
-        version: 0.7.0(czg@1.13.0)
+        specifier: workspace:*
+        version: link:../commitlint
       "@kriac/eslint-config":
-        specifier: 0.9.0
-        version: 0.9.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+        specifier: workspace:*
+        version: link:../eslint
       "@kriac/stylelint-config":
-        specifier: 0.7.0
-        version: 0.7.0(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2))
+        specifier: workspace:*
+        version: link:../stylelint
       czg:
         specifier: ^1.0.0
         version: 1.13.0
@@ -136,18 +130,6 @@ importers:
       stylelint:
         specifier: ^17.0.0
         version: 17.12.0(typescript@5.8.2)
-      stylelint-config-recess-order:
-        specifier: 7.7.0
-        version: 7.7.0(stylelint-order@8.1.1(stylelint@17.12.0(typescript@5.8.2)))(stylelint@17.12.0(typescript@5.8.2))
-      stylelint-config-recommended-vue:
-        specifier: 1.6.1
-        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.12.0(typescript@5.8.2))
-      stylelint-config-standard-scss:
-        specifier: 17.0.0
-        version: 17.0.0(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2))
-      stylelint-order:
-        specifier: 8.1.1
-        version: 8.1.1(stylelint@17.12.0(typescript@5.8.2))
     devDependencies:
       "@types/node":
         specifier: 25.6.0
@@ -162,8 +144,8 @@ importers:
   packages/stylelint:
     dependencies:
       postcss-html:
-        specifier: 1.8.1
-        version: 1.8.1
+        specifier: 2.0.0
+        version: 2.0.0(postcss@8.5.26)
       stylelint:
         specifier: ">=17.0.0"
         version: 17.12.0(typescript@5.8.2)
@@ -171,11 +153,11 @@ importers:
         specifier: 7.7.0
         version: 7.7.0(stylelint-order@8.1.1(stylelint@17.12.0(typescript@5.8.2)))(stylelint@17.12.0(typescript@5.8.2))
       stylelint-config-recommended-vue:
-        specifier: 1.6.1
-        version: 1.6.1(postcss-html@1.8.1)(stylelint@17.12.0(typescript@5.8.2))
+        specifier: 2.0.0
+        version: 2.0.0(postcss-html@2.0.0(postcss@8.5.26))(stylelint-config-html@2.0.0(postcss-html@2.0.0(postcss@8.5.26))(stylelint@17.12.0(typescript@5.8.2)))(stylelint-config-recommended-scss@17.0.1(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2)))(stylelint-config-recommended@18.0.0(stylelint@17.12.0(typescript@5.8.2)))(stylelint@17.12.0(typescript@5.8.2))
       stylelint-config-standard-scss:
         specifier: 17.0.0
-        version: 17.0.0(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2))
+        version: 17.0.0(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2))
       stylelint-order:
         specifier: 8.1.1
         version: 8.1.1(stylelint@17.12.0(typescript@5.8.2))
@@ -191,10 +173,10 @@ importers:
         version: 3.2.1(typescript@5.8.2)
 
 packages:
-  "@algolia/abtesting@1.21.0":
+  "@algolia/abtesting@1.22.0":
     resolution:
       {
-        integrity: sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==,
+        integrity: sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -230,94 +212,94 @@ packages:
       "@algolia/client-search": ">= 4.9.1 < 6"
       algoliasearch: ">= 4.9.1 < 6"
 
-  "@algolia/client-abtesting@5.55.0":
+  "@algolia/client-abtesting@5.56.0":
     resolution:
       {
-        integrity: sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==,
+        integrity: sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-analytics@5.55.0":
+  "@algolia/client-analytics@5.56.0":
     resolution:
       {
-        integrity: sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==,
+        integrity: sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-common@5.55.0":
+  "@algolia/client-common@5.56.0":
     resolution:
       {
-        integrity: sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==,
+        integrity: sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-insights@5.55.0":
+  "@algolia/client-insights@5.56.0":
     resolution:
       {
-        integrity: sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==,
+        integrity: sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-personalization@5.55.0":
+  "@algolia/client-personalization@5.56.0":
     resolution:
       {
-        integrity: sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==,
+        integrity: sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-query-suggestions@5.55.0":
+  "@algolia/client-query-suggestions@5.56.0":
     resolution:
       {
-        integrity: sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==,
+        integrity: sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-search@5.55.0":
+  "@algolia/client-search@5.56.0":
     resolution:
       {
-        integrity: sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==,
+        integrity: sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/ingestion@1.55.0":
+  "@algolia/ingestion@1.56.0":
     resolution:
       {
-        integrity: sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==,
+        integrity: sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/monitoring@1.55.0":
+  "@algolia/monitoring@1.56.0":
     resolution:
       {
-        integrity: sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==,
+        integrity: sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/recommend@5.55.0":
+  "@algolia/recommend@5.56.0":
     resolution:
       {
-        integrity: sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==,
+        integrity: sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/requester-browser-xhr@5.55.0":
+  "@algolia/requester-browser-xhr@5.56.0":
     resolution:
       {
-        integrity: sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==,
+        integrity: sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/requester-fetch@5.55.0":
+  "@algolia/requester-fetch@5.56.0":
     resolution:
       {
-        integrity: sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==,
+        integrity: sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/requester-node-http@5.55.0":
+  "@algolia/requester-node-http@5.56.0":
     resolution:
       {
-        integrity: sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==,
+        integrity: sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -356,13 +338,6 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-validator-identifier@8.0.0":
-    resolution:
-      {
-        integrity: sha512-kXxQVZHNOctSJJsqzmcbPSCEkM6oHNnDIkua7g9RCO9xRHj2eCiKvRx2KPdfWR9QxcGWnK/oArrtunmie3rL9g==,
-      }
-    engines: { node: ^22.18.0 || >=24.11.0 }
-
   "@babel/helper-validator-identifier@8.0.0-rc.6":
     resolution:
       {
@@ -370,20 +345,19 @@ packages:
       }
     engines: { node: ^22.18.0 || >=24.11.0 }
 
-  "@babel/parser@7.29.7":
+  "@babel/helper-validator-identifier@8.0.4":
     resolution:
       {
-        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
-      }
-    engines: { node: ">=6.0.0" }
-    hasBin: true
-
-  "@babel/parser@8.0.0":
-    resolution:
-      {
-        integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==,
+        integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==,
       }
     engines: { node: ^22.18.0 || >=24.11.0 }
+
+  "@babel/parser@7.29.8":
+    resolution:
+      {
+        integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
   "@babel/parser@8.0.0-rc.6":
@@ -394,30 +368,38 @@ packages:
     engines: { node: ^22.18.0 || >=24.11.0 }
     hasBin: true
 
-  "@babel/types@7.29.7":
+  "@babel/parser@8.0.4":
     resolution:
       {
-        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
+        integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==,
+      }
+    engines: { node: ^22.18.0 || >=24.11.0 }
+    hasBin: true
+
+  "@babel/types@7.29.8":
+    resolution:
+      {
+        integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/types@8.0.0":
+  "@babel/types@8.0.4":
     resolution:
       {
-        integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==,
+        integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==,
       }
     engines: { node: ^22.18.0 || >=24.11.0 }
 
-  "@cacheable/memory@2.0.9":
+  "@cacheable/memory@2.2.0":
     resolution:
       {
-        integrity: sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA==,
+        integrity: sha512-CTLKqLItRCEixEAewD3/j9DB3/o96gpTPD4eJ1v+DGOlxZRZncRQkGYqqnAGCscYd6RNeXfGeiuCphsPtqyIfQ==,
       }
 
-  "@cacheable/utils@2.4.1":
+  "@cacheable/utils@2.5.0":
     resolution:
       {
-        integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==,
+        integrity: sha512-buipgOVDkkPXNR5+xBpDw7Zk2n1EvU7qBJCNUcL7rhQ//kfpOXPAvQ511Os0vpLYJ1pZnvudNytkQt2hst3wqA==,
       }
 
   "@commitlint/cli@20.5.3":
@@ -548,10 +530,10 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  "@csstools/css-calc@3.2.1":
+  "@csstools/css-calc@3.3.0":
     resolution:
       {
-        integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==,
+        integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==,
       }
     engines: { node: ">=20.19.0" }
     peerDependencies:
@@ -567,10 +549,10 @@ packages:
     peerDependencies:
       "@csstools/css-tokenizer": ^4.0.0
 
-  "@csstools/css-syntax-patches-for-csstree@1.1.5":
+  "@csstools/css-syntax-patches-for-csstree@1.1.7":
     resolution:
       {
-        integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==,
+        integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==,
       }
     peerDependencies:
       css-tree: ^3.2.1
@@ -595,10 +577,10 @@ packages:
       "@csstools/css-parser-algorithms": ^4.0.0
       "@csstools/css-tokenizer": ^4.0.0
 
-  "@csstools/selector-resolve-nested@4.0.0":
+  "@csstools/selector-resolve-nested@4.0.1":
     resolution:
       {
-        integrity: sha512-9vAPxmp+Dx3wQBIUwc1v7Mdisw1kbbaGqXUM8QLTgWg7SoPGYtXBsMXvsFs/0Bn5yoFhcktzxNZGNaUt0VjgjA==,
+        integrity: sha512-j3vdQu0XwLME5qOTWxm8cnmvsf423R2YL6DbKklCHZwkDm7UdKNu6RPlw4REIJhSlKBICY3B70/7QZdicLqZgg==,
       }
     engines: { node: ">=20.19.0" }
     peerDependencies:
@@ -644,24 +626,6 @@ packages:
         optional: true
       search-insights:
         optional: true
-
-  "@emnapi/core@1.11.0":
-    resolution:
-      {
-        integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==,
-      }
-
-  "@emnapi/runtime@1.11.0":
-    resolution:
-      {
-        integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==,
-      }
-
-  "@emnapi/wasi-threads@1.2.2":
-    resolution:
-      {
-        integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
-      }
 
   "@esbuild/aix-ppc64@0.21.5":
     resolution:
@@ -870,10 +834,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  "@eslint-community/eslint-utils@4.9.1":
+  "@eslint-community/eslint-utils@4.10.1":
     resolution:
       {
-        integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+        integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==,
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
@@ -907,10 +871,10 @@ packages:
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@eslint/eslintrc@3.3.5":
+  "@eslint/eslintrc@3.3.6":
     resolution:
       {
-        integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==,
+        integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
@@ -970,10 +934,10 @@ packages:
       }
     engines: { node: ">=18.18" }
 
-  "@iconify-json/simple-icons@1.2.86":
+  "@iconify-json/simple-icons@1.2.93":
     resolution:
       {
-        integrity: sha512-t3jck5qPQuK1qy+bRn9eCoDQhIB7XSazKz1Fjp8hcan3XOAsTI5Mq/s3F0ekOKSvMQqkVORYK6ns6o6T9f5EMA==,
+        integrity: sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw==,
       }
 
   "@iconify/types@2.0.0":
@@ -1022,38 +986,14 @@ packages:
         integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==,
       }
 
-  "@kriac/commitlint-config@0.7.0":
+  "@napi-rs/lzma-linux-x64-gnu@1.5.1":
     resolution:
       {
-        integrity: sha512-WstyGqL9OGbPf+21lYGjb4Qrgby7UZxKFlxoYReK7Vq9DJwcufuM6emDaAEXtt//D/FsgH1eZtthPLfHTWJpKg==,
+        integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==,
       }
-    peerDependencies:
-      czg: ">=1.0.0"
-
-  "@kriac/eslint-config@0.9.0":
-    resolution:
-      {
-        integrity: sha512-pvcZ/C4uzubcnpdxfP42tzbOXn9Teylojlc24J/9R+uuPGCjF/kWrjiImOWH0qbNH4oKXyd59W1mVSDzRTjHuA==,
-      }
-    peerDependencies:
-      eslint: ">=9.0.0"
-
-  "@kriac/stylelint-config@0.7.0":
-    resolution:
-      {
-        integrity: sha512-S/4XzIczfUD2G3YHPMdwFvrtf8oWdBVr2HNqt3q6eO5yfd+TDJHXnN1jQ+i1vffILwYpKNFUtHT2b4rdOErwMg==,
-      }
-    peerDependencies:
-      stylelint: ">=17.0.0"
-
-  "@napi-rs/wasm-runtime@1.1.5":
-    resolution:
-      {
-        integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==,
-      }
-    peerDependencies:
-      "@emnapi/core": ^1.7.1
-      "@emnapi/runtime": ^1.7.1
+    engines: { node: ^22.20 || ^24.12 || >=25 }
+    cpu: [x64]
+    os: [linux]
 
   "@nodelib/fs.scandir@2.1.5":
     resolution:
@@ -1076,135 +1016,11 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  "@oxc-project/types@0.135.0":
+  "@oxc-project/types@0.143.0":
     resolution:
       {
-        integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==,
+        integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==,
       }
-
-  "@parcel/watcher-android-arm64@2.5.6":
-    resolution:
-      {
-        integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm64]
-    os: [android]
-
-  "@parcel/watcher-darwin-arm64@2.5.6":
-    resolution:
-      {
-        integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm64]
-    os: [darwin]
-
-  "@parcel/watcher-darwin-x64@2.5.6":
-    resolution:
-      {
-        integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [x64]
-    os: [darwin]
-
-  "@parcel/watcher-freebsd-x64@2.5.6":
-    resolution:
-      {
-        integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [x64]
-    os: [freebsd]
-
-  "@parcel/watcher-linux-arm-glibc@2.5.6":
-    resolution:
-      {
-        integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm]
-    os: [linux]
-
-  "@parcel/watcher-linux-arm-musl@2.5.6":
-    resolution:
-      {
-        integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm]
-    os: [linux]
-
-  "@parcel/watcher-linux-arm64-glibc@2.5.6":
-    resolution:
-      {
-        integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm64]
-    os: [linux]
-
-  "@parcel/watcher-linux-arm64-musl@2.5.6":
-    resolution:
-      {
-        integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm64]
-    os: [linux]
-
-  "@parcel/watcher-linux-x64-glibc@2.5.6":
-    resolution:
-      {
-        integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [x64]
-    os: [linux]
-
-  "@parcel/watcher-linux-x64-musl@2.5.6":
-    resolution:
-      {
-        integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [x64]
-    os: [linux]
-
-  "@parcel/watcher-win32-arm64@2.5.6":
-    resolution:
-      {
-        integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [arm64]
-    os: [win32]
-
-  "@parcel/watcher-win32-ia32@2.5.6":
-    resolution:
-      {
-        integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [ia32]
-    os: [win32]
-
-  "@parcel/watcher-win32-x64@2.5.6":
-    resolution:
-      {
-        integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==,
-      }
-    engines: { node: ">= 10.0.0" }
-    cpu: [x64]
-    os: [win32]
-
-  "@parcel/watcher@2.5.6":
-    resolution:
-      {
-        integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==,
-      }
-    engines: { node: ">= 10.0.0" }
 
   "@quansync/fs@1.0.0":
     resolution:
@@ -1212,135 +1028,127 @@ packages:
         integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==,
       }
 
-  "@rolldown/binding-android-arm64@1.1.1":
+  "@rolldown/binding-android-arm64@1.2.3":
     resolution:
       {
-        integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==,
+        integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-darwin-arm64@1.1.1":
+  "@rolldown/binding-darwin-arm64@1.2.3":
     resolution:
       {
-        integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==,
+        integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-x64@1.1.1":
+  "@rolldown/binding-darwin-x64@1.2.3":
     resolution:
       {
-        integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==,
+        integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-freebsd-x64@1.1.1":
+  "@rolldown/binding-freebsd-x64@1.2.3":
     resolution:
       {
-        integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==,
+        integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.1.1":
+  "@rolldown/binding-linux-arm-gnueabihf@1.2.3":
     resolution:
       {
-        integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==,
+        integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@rolldown/binding-linux-arm64-gnu@1.1.1":
+  "@rolldown/binding-linux-arm64-gnu@1.2.3":
     resolution:
       {
-        integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==,
+        integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
 
-  "@rolldown/binding-linux-arm64-musl@1.1.1":
+  "@rolldown/binding-linux-arm64-musl@1.2.3":
     resolution:
       {
-        integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==,
+        integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.1.1":
+  "@rolldown/binding-linux-ppc64-gnu@1.2.3":
     resolution:
       {
-        integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==,
+        integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
 
-  "@rolldown/binding-linux-s390x-gnu@1.1.1":
+  "@rolldown/binding-linux-s390x-gnu@1.2.3":
     resolution:
       {
-        integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==,
+        integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
 
-  "@rolldown/binding-linux-x64-gnu@1.1.1":
+  "@rolldown/binding-linux-x64-gnu@1.2.3":
     resolution:
       {
-        integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==,
+        integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
 
-  "@rolldown/binding-linux-x64-musl@1.1.1":
+  "@rolldown/binding-linux-x64-musl@1.2.3":
     resolution:
       {
-        integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==,
+        integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
 
-  "@rolldown/binding-openharmony-arm64@1.1.1":
+  "@rolldown/binding-openharmony-arm64@1.2.3":
     resolution:
       {
-        integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==,
+        integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-wasm32-wasi@1.1.1":
+  "@rolldown/binding-win32-arm64-msvc@1.2.3":
     resolution:
       {
-        integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [wasm32]
-
-  "@rolldown/binding-win32-arm64-msvc@1.1.1":
-    resolution:
-      {
-        integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==,
+        integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.1.1":
+  "@rolldown/binding-win32-x64-msvc@1.2.3":
     resolution:
       {
-        integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==,
+        integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -1358,202 +1166,202 @@ packages:
         integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
       }
 
-  "@rollup/rollup-android-arm-eabi@4.62.0":
+  "@rollup/rollup-android-arm-eabi@4.62.4":
     resolution:
       {
-        integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==,
+        integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==,
       }
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.62.0":
+  "@rollup/rollup-android-arm64@4.62.4":
     resolution:
       {
-        integrity: sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==,
+        integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==,
       }
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.62.0":
+  "@rollup/rollup-darwin-arm64@4.62.4":
     resolution:
       {
-        integrity: sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==,
+        integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.62.0":
+  "@rollup/rollup-darwin-x64@4.62.4":
     resolution:
       {
-        integrity: sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==,
+        integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.62.0":
+  "@rollup/rollup-freebsd-arm64@4.62.4":
     resolution:
       {
-        integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==,
+        integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==,
       }
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.62.0":
+  "@rollup/rollup-freebsd-x64@4.62.4":
     resolution:
       {
-        integrity: sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==,
+        integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==,
       }
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.62.0":
+  "@rollup/rollup-linux-arm-gnueabihf@4.62.4":
     resolution:
       {
-        integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==,
+        integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==,
       }
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.62.0":
+  "@rollup/rollup-linux-arm-musleabihf@4.62.4":
     resolution:
       {
-        integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==,
+        integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==,
       }
     cpu: [arm]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-gnu@4.62.0":
+  "@rollup/rollup-linux-arm64-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==,
+        integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-arm64-musl@4.62.0":
+  "@rollup/rollup-linux-arm64-musl@4.62.4":
     resolution:
       {
-        integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==,
+        integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-gnu@4.62.0":
+  "@rollup/rollup-linux-loong64-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==,
+        integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==,
       }
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-loong64-musl@4.62.0":
+  "@rollup/rollup-linux-loong64-musl@4.62.4":
     resolution:
       {
-        integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==,
+        integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==,
       }
     cpu: [loong64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.62.0":
+  "@rollup/rollup-linux-ppc64-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==,
+        integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==,
       }
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-ppc64-musl@4.62.0":
+  "@rollup/rollup-linux-ppc64-musl@4.62.4":
     resolution:
       {
-        integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==,
+        integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==,
       }
     cpu: [ppc64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.62.0":
+  "@rollup/rollup-linux-riscv64-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==,
+        integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==,
       }
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-riscv64-musl@4.62.0":
+  "@rollup/rollup-linux-riscv64-musl@4.62.4":
     resolution:
       {
-        integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==,
+        integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==,
       }
     cpu: [riscv64]
     os: [linux]
 
-  "@rollup/rollup-linux-s390x-gnu@4.62.0":
+  "@rollup/rollup-linux-s390x-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==,
+        integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==,
       }
     cpu: [s390x]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-gnu@4.62.0":
+  "@rollup/rollup-linux-x64-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==,
+        integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-linux-x64-musl@4.62.0":
+  "@rollup/rollup-linux-x64-musl@4.62.4":
     resolution:
       {
-        integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==,
+        integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@rollup/rollup-openbsd-x64@4.62.0":
+  "@rollup/rollup-openbsd-x64@4.62.4":
     resolution:
       {
-        integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==,
+        integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==,
       }
     cpu: [x64]
     os: [openbsd]
 
-  "@rollup/rollup-openharmony-arm64@4.62.0":
+  "@rollup/rollup-openharmony-arm64@4.62.4":
     resolution:
       {
-        integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==,
+        integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==,
       }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.62.0":
+  "@rollup/rollup-win32-arm64-msvc@4.62.4":
     resolution:
       {
-        integrity: sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==,
+        integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==,
       }
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.62.0":
+  "@rollup/rollup-win32-ia32-msvc@4.62.4":
     resolution:
       {
-        integrity: sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==,
+        integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==,
       }
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.62.0":
+  "@rollup/rollup-win32-x64-gnu@4.62.4":
     resolution:
       {
-        integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==,
+        integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.62.0":
+  "@rollup/rollup-win32-x64-msvc@4.62.4":
     resolution:
       {
-        integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==,
+        integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==,
       }
     cpu: [x64]
     os: [win32]
@@ -1627,12 +1435,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@tybys/wasm-util@0.10.2":
-    resolution:
-      {
-        integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==,
-      }
-
   "@types/esrecurse@4.3.1":
     resolution:
       {
@@ -1645,10 +1447,10 @@ packages:
         integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
       }
 
-  "@types/hast@3.0.4":
+  "@types/hast@3.0.5":
     resolution:
       {
-        integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==,
+        integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==,
       }
 
   "@types/jsesc@2.5.1":
@@ -1705,99 +1507,99 @@ packages:
         integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.61.1":
+  "@typescript-eslint/eslint-plugin@8.66.0":
     resolution:
       {
-        integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==,
+        integrity: sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.61.1
+      "@typescript-eslint/parser": ^8.66.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.61.1":
+  "@typescript-eslint/parser@8.66.0":
     resolution:
       {
-        integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/project-service@8.61.1":
-    resolution:
-      {
-        integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/scope-manager@8.61.1":
-    resolution:
-      {
-        integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/tsconfig-utils@8.61.1":
-    resolution:
-      {
-        integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/type-utils@8.61.1":
-    resolution:
-      {
-        integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==,
+        integrity: sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.61.1":
+  "@typescript-eslint/project-service@8.66.0":
     resolution:
       {
-        integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.61.1":
-    resolution:
-      {
-        integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==,
+        integrity: sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.61.1":
+  "@typescript-eslint/scope-manager@8.66.0":
     resolution:
       {
-        integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==,
+        integrity: sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.66.0":
+    resolution:
+      {
+        integrity: sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.66.0":
+    resolution:
+      {
+        integrity: sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.61.1":
+  "@typescript-eslint/types@8.66.0":
     resolution:
       {
-        integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==,
+        integrity: sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@ungap/structured-clone@1.3.1":
+  "@typescript-eslint/typescript-estree@8.66.0":
     resolution:
       {
-        integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==,
+        integrity: sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.66.0":
+    resolution:
+      {
+        integrity: sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.66.0":
+    resolution:
+      {
+        integrity: sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@ungap/structured-clone@1.3.3":
+    resolution:
+      {
+        integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==,
       }
 
   "@vitejs/plugin-vue@5.2.4":
@@ -1850,10 +1652,10 @@ packages:
         integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==,
       }
 
-  "@vue/compiler-core@3.5.38":
+  "@vue/compiler-core@3.5.41":
     resolution:
       {
-        integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==,
+        integrity: sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==,
       }
 
   "@vue/compiler-dom@3.5.13":
@@ -1868,10 +1670,10 @@ packages:
         integrity: sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==,
       }
 
-  "@vue/compiler-dom@3.5.38":
+  "@vue/compiler-dom@3.5.41":
     resolution:
       {
-        integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==,
+        integrity: sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==,
       }
 
   "@vue/compiler-sfc@3.5.13":
@@ -1898,22 +1700,22 @@ packages:
         integrity: sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==,
       }
 
-  "@vue/devtools-api@7.7.9":
+  "@vue/devtools-api@7.7.10":
     resolution:
       {
-        integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==,
+        integrity: sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA==,
       }
 
-  "@vue/devtools-kit@7.7.9":
+  "@vue/devtools-kit@7.7.10":
     resolution:
       {
-        integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==,
+        integrity: sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw==,
       }
 
-  "@vue/devtools-shared@7.7.9":
+  "@vue/devtools-shared@7.7.10":
     resolution:
       {
-        integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==,
+        integrity: sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ==,
       }
 
   "@vue/language-core@3.2.1":
@@ -1986,10 +1788,10 @@ packages:
         integrity: sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==,
       }
 
-  "@vue/shared@3.5.38":
+  "@vue/shared@3.5.41":
     resolution:
       {
-        integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==,
+        integrity: sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==,
       }
 
   "@vueuse/core@12.8.2":
@@ -2062,10 +1864,10 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn@8.17.0:
+  acorn@8.18.0:
     resolution:
       {
-        integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
+        integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==,
       }
     engines: { node: ">=0.4.0" }
     hasBin: true
@@ -2082,10 +1884,10 @@ packages:
         integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
-  algoliasearch@5.55.0:
+  algoliasearch@5.56.0:
     resolution:
       {
-        integrity: sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==,
+        integrity: sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -2208,18 +2010,18 @@ packages:
         integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
       }
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     resolution:
       {
-        integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==,
+        integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==,
       }
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     resolution:
       {
-        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+        integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==,
       }
-    engines: { node: 18 || 20 || >=22 }
+    engines: { node: 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -2235,10 +2037,10 @@ packages:
       }
     engines: { node: ">=20.19.0" }
 
-  cacheable@2.3.5:
+  cacheable@2.5.0:
     resolution:
       {
-        integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==,
+        integrity: sha512-60cyAOytib/OzBw1JNSoSV/boK1AtHryDIjvVBk7XbN4ugfkM3+Sry7fEjNgPMGgOjuaZPAp8ruZ0Cxafwyq9g==,
       }
 
   callsites@3.1.0:
@@ -2279,13 +2081,6 @@ packages:
         integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
       }
     engines: { node: ">= 8.10.0" }
-
-  chokidar@5.0.0:
-    resolution:
-      {
-        integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
-      }
-    engines: { node: ">= 20.19.0" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -2485,13 +2280,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  detect-libc@2.1.2:
-    resolution:
-      {
-        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
-      }
-    engines: { node: ">=8" }
-
   devlop@1.1.0:
     resolution:
       {
@@ -2601,10 +2389,10 @@ packages:
         integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==,
       }
 
-  es-toolkit@1.47.1:
+  es-toolkit@1.50.0:
     resolution:
       {
-        integrity: sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q==,
+        integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==,
       }
 
   esbuild@0.21.5:
@@ -2638,19 +2426,19 @@ packages:
     peerDependencies:
       eslint: ">=7.0.0"
 
-  eslint-plugin-perfectionist@5.9.1:
+  eslint-plugin-perfectionist@5.10.1:
     resolution:
       {
-        integrity: sha512-30mHLNfEhzwaq5cquyWgnzrNXvT8AzwIwyeH5aj4U5ajhHSF2uiO6i09xpMDLv7koaZVTjLsvYF4m3gK/15tyA==,
+        integrity: sha512-Kprsp9Us0GqAesYaAIzUViw57xYp5WBqzXrcE0Mtww++E5fexWXYBipMuuD7yvyH4vvpBH0+oJ+OMAmZ0oYXkw==,
       }
     engines: { node: ^20.0.0 || >=22.0.0 }
     peerDependencies:
       eslint: ^8.45.0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-vue@10.9.2:
+  eslint-plugin-vue@10.10.0:
     resolution:
       {
-        integrity: sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==,
+        integrity: sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -2797,10 +2585,10 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
-  fast-uri@3.1.2:
+  fast-uri@3.1.5:
     resolution:
       {
-        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+        integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==,
       }
 
   fastest-levenshtein@1.0.16:
@@ -2828,10 +2616,10 @@ packages:
       picomatch:
         optional: true
 
-  file-entry-cache@11.1.3:
+  file-entry-cache@11.1.5:
     resolution:
       {
-        integrity: sha512-oMbq0PD6VIiIwMF6LIa7MEwd/l9huKwmqRKXqmrkqIZv8CvRbfowL+L0ryAl8h//HfAS0zS+4SbYoRyAoA6BJA==,
+        integrity: sha512-+PFTHITI08JIGhnNpGNI8T8inUpgZfk3GNEqfT9R2zZV2iFXg3CvqzSl/uEhs7TSGujYRELEANyDvS8Fj7+S7Q==,
       }
 
   file-entry-cache@8.0.0:
@@ -2862,16 +2650,16 @@ packages:
       }
     engines: { node: ">=16" }
 
-  flat-cache@6.1.22:
+  flat-cache@6.1.23:
     resolution:
       {
-        integrity: sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==,
+        integrity: sha512-f++BY9pTk+983xK1FLzlLpmM0i0z+jHmx3QESGkURMXujQZz1k5wzwX6hjnQ8goaD0B+sYnDK1yZ6MTyZfUaqA==,
       }
 
-  flatted@3.4.2:
+  flatted@3.4.4:
     resolution:
       {
-        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
+        integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==,
       }
 
   focus-trap@7.8.0:
@@ -2915,6 +2703,7 @@ packages:
         integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==,
       }
     engines: { node: ">=18" }
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob-parent@5.1.2:
@@ -2959,10 +2748,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  globby@16.2.0:
+  globby@16.2.3:
     resolution:
       {
-        integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==,
+        integrity: sha512-VZX7TV7jmd/pn71vdnLKtgwy1IWqc3KjI9x1/UtPkwoKk5fKrNLY30ltDe3cAM5xruIN7YuuaulFt133jRrKZg==,
       }
     engines: { node: ">=20" }
 
@@ -3042,10 +2831,10 @@ packages:
         integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==,
       }
 
-  htmlparser2@8.0.2:
+  htmlparser2@9.1.0:
     resolution:
       {
-        integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==,
+        integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==,
       }
 
   husky@9.1.7:
@@ -3063,10 +2852,10 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  ignore@7.0.5:
+  ignore@7.0.6:
     resolution:
       {
-        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+        integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==,
       }
     engines: { node: ">= 4" }
 
@@ -3074,12 +2863,6 @@ packages:
     resolution:
       {
         integrity: sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==,
-      }
-
-  immutable@5.1.6:
-    resolution:
-      {
-        integrity: sha512-q1swsS8K7L8usSHuOqF2TAoCCkonYz0SG38wLAggaa4Wml70zixIvt2ql4coQ2C2B3hTjltJry4r6bULwgAXLQ==,
       }
 
   import-fresh@3.3.1:
@@ -3230,10 +3013,10 @@ packages:
         integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==,
       }
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     resolution:
       {
-        integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==,
+        integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==,
       }
     hasBin: true
 
@@ -3449,10 +3232,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     resolution:
       {
-        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+        integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -3492,10 +3275,10 @@ packages:
         integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==,
       }
 
-  nanoid@3.3.12:
+  nanoid@3.3.18:
     resolution:
       {
-        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+        integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -3513,12 +3296,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  node-addon-api@7.1.1:
-    resolution:
-      {
-        integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==,
-      }
-
   normalize-path@3.0.0:
     resolution:
       {
@@ -3532,10 +3309,10 @@ packages:
         integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
       }
 
-  obug@2.1.3:
+  obug@2.1.4:
     resolution:
       {
-        integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
+        integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==,
       }
     engines: { node: ">=12.20.0" }
 
@@ -3632,19 +3409,21 @@ packages:
       }
     engines: { node: ">=8.6" }
 
-  picomatch@4.0.4:
+  picomatch@4.0.5:
     resolution:
       {
-        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+        integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
       }
     engines: { node: ">=12" }
 
-  postcss-html@1.8.1:
+  postcss-html@2.0.0:
     resolution:
       {
-        integrity: sha512-OLF6P7qctfAWayOhLpcVnTGqVeJzu2W3WpIYelfz2+JV5oGxfkcEvweN9U4XpeqE0P98dcD9ssusGwlF0TK0uQ==,
+        integrity: sha512-f2Rvw5FCollEfVj3wfN7JdQb7n2rNIthW+epw2EByio7M6P7RH0BTj8a/ODHrUXd0cmO7ychb6YniymV93182Q==,
       }
-    engines: { node: ^12 || >=14 }
+    engines: { node: ^22.12 || >=24 }
+    peerDependencies:
+      postcss: ^8.5.0
 
   postcss-media-query-parser@0.2.3:
     resolution:
@@ -3657,15 +3436,6 @@ packages:
       {
         integrity: sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==,
       }
-
-  postcss-safe-parser@6.0.0:
-    resolution:
-      {
-        integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==,
-      }
-    engines: { node: ">=12.0" }
-    peerDependencies:
-      postcss: ^8.3.3
 
   postcss-safe-parser@7.0.1:
     resolution:
@@ -3685,10 +3455,10 @@ packages:
     peerDependencies:
       postcss: ^8.4.29
 
-  postcss-selector-parser@7.1.4:
+  postcss-selector-parser@7.1.5:
     resolution:
       {
-        integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==,
+        integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==,
       }
     engines: { node: ">=4" }
 
@@ -3706,18 +3476,23 @@ packages:
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     resolution:
       {
-        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+        integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
-  preact@10.29.2:
+  preact@10.29.8:
     resolution:
       {
-        integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==,
+        integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==,
       }
+    peerDependencies:
+      preact-render-to-string: ">=5"
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prelude-ls@1.2.1:
     resolution:
@@ -3772,13 +3547,6 @@ packages:
         integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
       }
     engines: { node: ">=8.10.0" }
-
-  readdirp@5.0.0:
-    resolution:
-      {
-        integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
-      }
-    engines: { node: ">= 20.19.0" }
 
   regex-recursion@6.0.2:
     resolution:
@@ -3874,18 +3642,18 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.1.1:
+  rolldown@1.2.3:
     resolution:
       {
-        integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==,
+        integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
 
-  rollup@4.62.0:
+  rollup@4.62.4:
     resolution:
       {
-        integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==,
+        integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==,
       }
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
@@ -3895,14 +3663,6 @@ packages:
       {
         integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
       }
-
-  sass@1.101.0:
-    resolution:
-      {
-        integrity: sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==,
-      }
-    engines: { node: ">=20.19.0" }
-    hasBin: true
 
   sass@1.78.0:
     resolution:
@@ -3918,10 +3678,10 @@ packages:
         integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==,
       }
 
-  semver@7.8.4:
+  semver@7.8.5:
     resolution:
       {
-        integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==,
+        integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==,
       }
     engines: { node: ">=10" }
     hasBin: true
@@ -4022,10 +3782,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  string-width@8.2.1:
+  string-width@8.2.2:
     resolution:
       {
-        integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==,
+        integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==,
       }
     engines: { node: ">=20" }
 
@@ -4056,15 +3816,15 @@ packages:
       }
     engines: { node: ">=8" }
 
-  stylelint-config-html@1.1.0:
+  stylelint-config-html@2.0.0:
     resolution:
       {
-        integrity: sha512-IZv4IVESjKLumUGi+HWeb7skgO6/g4VMuAYrJdlqQFndgbj6WJAXPhaysvBiXefX79upBdQVumgYcdd17gCpjQ==,
+        integrity: sha512-Lk1NPEdUxzHkPv3ehktjpiOk4MPaqQ3H8fkvhxdWlQpaZCm9ze0SoMbRQLqkUxEMfPE1G9/x968uxm/+d2njoA==,
       }
-    engines: { node: ^12 || >=14 }
+    engines: { node: ^22.12 || >=24 }
     peerDependencies:
-      postcss-html: ^1.0.0
-      stylelint: ">=14.0.0"
+      postcss-html: ^2.0.0
+      stylelint: ">=16.0.0"
 
   stylelint-config-recess-order@7.7.0:
     resolution:
@@ -4088,15 +3848,21 @@ packages:
       postcss:
         optional: true
 
-  stylelint-config-recommended-vue@1.6.1:
+  stylelint-config-recommended-vue@2.0.0:
     resolution:
       {
-        integrity: sha512-lLW7hTIMBiTfjenGuDq2kyHA6fBWd/+Df7MO4/AWOxiFeXP9clbpKgg27kHfwA3H7UNMGC7aeP3mNlZB5LMmEQ==,
+        integrity: sha512-SrGBfxgX+CmxRoFOl6HHhfKrp+6YvGnuiHj/N+/deI310eGNhix8aZOtPHG+OeqB6+5Si5BbjsZiC+kULUO1DQ==,
       }
-    engines: { node: ^12 || >=14 }
+    engines: { node: ^22.12 || >=24 }
     peerDependencies:
-      postcss-html: ^1.0.0
-      stylelint: ">=14.0.0"
+      postcss-html: ^2.0.0
+      stylelint: ">=16.0.0"
+      stylelint-config-html: ">=2.0.0"
+      stylelint-config-recommended: ">=14.0.0"
+      stylelint-config-recommended-scss: ">=14.0.0"
+    peerDependenciesMeta:
+      stylelint-config-recommended-scss:
+        optional: true
 
   stylelint-config-recommended@18.0.0:
     resolution:
@@ -4176,10 +3942,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  supports-hyperlinks@4.4.0:
+  supports-hyperlinks@4.5.0:
     resolution:
       {
-        integrity: sha512-UKbpT93hN5Nr9go5UY7bopIB9YQlMz9nm/ct4IXt/irb5YRkn9WaqrOBJGZ5Pwvsd5FQzSVeYlGdXoCAPQZrPg==,
+        integrity: sha512-ZW2OvfeCXrNTbLakPUzjQG922EeGCOteFSVoek5DKStTh898wf7zgtuFlzQN8HfZCxC3Eh02yJVrRW51hADf+w==,
       }
     engines: { node: ">=20" }
 
@@ -4189,10 +3955,10 @@ packages:
         integrity: sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==,
       }
 
-  tabbable@6.4.0:
+  tabbable@6.5.0:
     resolution:
       {
-        integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==,
+        integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==,
       }
 
   table@6.9.0:
@@ -4202,10 +3968,10 @@ packages:
       }
     engines: { node: ">=10.0.0" }
 
-  tinyexec@1.2.4:
+  tinyexec@1.3.0:
     resolution:
       {
-        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
+        integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==,
       }
     engines: { node: ">=18" }
 
@@ -4282,12 +4048,6 @@ packages:
       unrun:
         optional: true
 
-  tslib@2.8.1:
-    resolution:
-      {
-        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-      }
-
   type-check@0.4.0:
     resolution:
       {
@@ -4295,10 +4055,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  typescript-eslint@8.61.1:
+  typescript-eslint@8.66.0:
     resolution:
       {
-        integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==,
+        integrity: sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -4524,12 +4284,12 @@ packages:
       }
     engines: { node: ^20.17.0 || >=22.9.0 }
 
-  xml-name-validator@4.0.0:
+  xml-name-validator@5.0.0:
     resolution:
       {
-        integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==,
+        integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==,
       }
-    engines: { node: ">=12" }
+    engines: { node: ">=18" }
 
   y18n@5.0.8:
     resolution:
@@ -4553,10 +4313,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  yargs@17.7.2:
+  yargs@17.7.3:
     resolution:
       {
-        integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==,
+        integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==,
       }
     engines: { node: ">=12" }
 
@@ -4574,117 +4334,117 @@ packages:
       }
 
 snapshots:
-  "@algolia/abtesting@1.21.0":
+  "@algolia/abtesting@1.22.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)(search-insights@2.17.3)":
+  "@algolia/autocomplete-core@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-plugin-algolia-insights": 1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)(search-insights@2.17.3)
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)
+      "@algolia/autocomplete-plugin-algolia-insights": 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
       - search-insights
 
-  "@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)(search-insights@2.17.3)":
+  "@algolia/autocomplete-plugin-algolia-insights@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)
+      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
 
-  "@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)":
+  "@algolia/autocomplete-preset-algolia@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)":
     dependencies:
-      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)
-      "@algolia/client-search": 5.55.0
-      algoliasearch: 5.55.0
+      "@algolia/autocomplete-shared": 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
+      "@algolia/client-search": 5.56.0
+      algoliasearch: 5.56.0
 
-  "@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)":
+  "@algolia/autocomplete-shared@1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)":
     dependencies:
-      "@algolia/client-search": 5.55.0
-      algoliasearch: 5.55.0
+      "@algolia/client-search": 5.56.0
+      algoliasearch: 5.56.0
 
-  "@algolia/client-abtesting@5.55.0":
+  "@algolia/client-abtesting@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/client-analytics@5.55.0":
+  "@algolia/client-analytics@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/client-common@5.55.0": {}
+  "@algolia/client-common@5.56.0": {}
 
-  "@algolia/client-insights@5.55.0":
+  "@algolia/client-insights@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/client-personalization@5.55.0":
+  "@algolia/client-personalization@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/client-query-suggestions@5.55.0":
+  "@algolia/client-query-suggestions@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/client-search@5.55.0":
+  "@algolia/client-search@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/ingestion@1.55.0":
+  "@algolia/ingestion@1.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/monitoring@1.55.0":
+  "@algolia/monitoring@1.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/recommend@5.55.0":
+  "@algolia/recommend@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
-  "@algolia/requester-browser-xhr@5.55.0":
+  "@algolia/requester-browser-xhr@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
+      "@algolia/client-common": 5.56.0
 
-  "@algolia/requester-fetch@5.55.0":
+  "@algolia/requester-fetch@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
+      "@algolia/client-common": 5.56.0
 
-  "@algolia/requester-node-http@5.55.0":
+  "@algolia/requester-node-http@5.56.0":
     dependencies:
-      "@algolia/client-common": 5.55.0
+      "@algolia/client-common": 5.56.0
 
   "@babel/code-frame@7.29.7":
     dependencies:
@@ -4695,7 +4455,7 @@ snapshots:
   "@babel/generator@8.0.0-rc.6":
     dependencies:
       "@babel/parser": 8.0.0-rc.6
-      "@babel/types": 8.0.0
+      "@babel/types": 8.0.4
       "@jridgewell/gen-mapping": 0.3.13
       "@jridgewell/trace-mapping": 0.3.31
       "@types/jsesc": 2.5.1
@@ -4707,40 +4467,40 @@ snapshots:
 
   "@babel/helper-validator-identifier@7.29.7": {}
 
-  "@babel/helper-validator-identifier@8.0.0": {}
-
   "@babel/helper-validator-identifier@8.0.0-rc.6": {}
 
-  "@babel/parser@7.29.7":
-    dependencies:
-      "@babel/types": 7.29.7
+  "@babel/helper-validator-identifier@8.0.4": {}
 
-  "@babel/parser@8.0.0":
+  "@babel/parser@7.29.8":
     dependencies:
-      "@babel/types": 8.0.0
+      "@babel/types": 7.29.8
 
   "@babel/parser@8.0.0-rc.6":
     dependencies:
-      "@babel/types": 8.0.0
+      "@babel/types": 8.0.4
 
-  "@babel/types@7.29.7":
+  "@babel/parser@8.0.4":
+    dependencies:
+      "@babel/types": 8.0.4
+
+  "@babel/types@7.29.8":
     dependencies:
       "@babel/helper-string-parser": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
 
-  "@babel/types@8.0.0":
+  "@babel/types@8.0.4":
     dependencies:
       "@babel/helper-string-parser": 8.0.0
-      "@babel/helper-validator-identifier": 8.0.0
+      "@babel/helper-validator-identifier": 8.0.4
 
-  "@cacheable/memory@2.0.9":
+  "@cacheable/memory@2.2.0":
     dependencies:
-      "@cacheable/utils": 2.4.1
+      "@cacheable/utils": 2.5.0
       "@keyv/bigmap": 1.3.1(keyv@5.6.0)
       hookified: 1.15.1
       keyv: 5.6.0
 
-  "@cacheable/utils@2.4.1":
+  "@cacheable/utils@2.5.0":
     dependencies:
       hashery: 1.5.1
       keyv: 5.6.0
@@ -4752,8 +4512,8 @@ snapshots:
       "@commitlint/load": 20.5.3(@types/node@25.6.0)(typescript@5.8.2)
       "@commitlint/read": 20.5.0(conventional-commits-parser@6.4.0)
       "@commitlint/types": 20.5.0
-      tinyexec: 1.2.4
-      yargs: 17.7.2
+      tinyexec: 1.3.0
+      yargs: 17.7.3
     transitivePeerDependencies:
       - "@types/node"
       - conventional-commits-filter
@@ -4768,7 +4528,7 @@ snapshots:
   "@commitlint/ensure@20.5.3":
     dependencies:
       "@commitlint/types": 20.5.0
-      es-toolkit: 1.47.1
+      es-toolkit: 1.50.0
 
   "@commitlint/execute-rule@20.0.0": {}
 
@@ -4780,7 +4540,7 @@ snapshots:
   "@commitlint/is-ignored@20.5.0":
     dependencies:
       "@commitlint/types": 20.5.0
-      semver: 7.8.4
+      semver: 7.8.5
 
   "@commitlint/lint@20.5.3":
     dependencies:
@@ -4797,7 +4557,7 @@ snapshots:
       "@commitlint/types": 20.5.0
       cosmiconfig: 9.0.2(typescript@5.8.2)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.2(typescript@5.8.2))(typescript@5.8.2)
-      es-toolkit: 1.47.1
+      es-toolkit: 1.50.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -4818,7 +4578,7 @@ snapshots:
       "@commitlint/types": 20.5.0
       git-raw-commits: 5.0.1(conventional-commits-parser@6.4.0)
       minimist: 1.2.8
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
@@ -4827,7 +4587,7 @@ snapshots:
     dependencies:
       "@commitlint/config-validator": 20.5.0
       "@commitlint/types": 20.5.0
-      es-toolkit: 1.47.1
+      es-toolkit: 1.50.0
       global-directory: 5.0.0
       import-meta-resolve: 4.2.0
       resolve-from: 5.0.0
@@ -4854,11 +4614,11 @@ snapshots:
     dependencies:
       "@simple-libs/child-process-utils": 1.0.2
       "@simple-libs/stream-utils": 1.2.0
-      semver: 7.8.4
+      semver: 7.8.5
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  "@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
+  "@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
     dependencies:
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-tokenizer": 4.0.0
@@ -4867,7 +4627,7 @@ snapshots:
     dependencies:
       "@csstools/css-tokenizer": 4.0.0
 
-  "@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)":
+  "@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)":
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -4878,53 +4638,38 @@ snapshots:
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-tokenizer": 4.0.0
 
-  "@csstools/selector-resolve-nested@4.0.0(postcss-selector-parser@7.1.4)":
+  "@csstools/selector-resolve-nested@4.0.1(postcss-selector-parser@7.1.5)":
     dependencies:
-      postcss-selector-parser: 7.1.4
+      postcss-selector-parser: 7.1.5
 
-  "@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.4)":
+  "@csstools/selector-specificity@6.0.0(postcss-selector-parser@7.1.5)":
     dependencies:
-      postcss-selector-parser: 7.1.4
+      postcss-selector-parser: 7.1.5
 
   "@docsearch/css@3.8.2": {}
 
-  "@docsearch/js@3.8.2(@algolia/client-search@5.55.0)(search-insights@2.17.3)":
+  "@docsearch/js@3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)":
     dependencies:
-      "@docsearch/react": 3.8.2(@algolia/client-search@5.55.0)(search-insights@2.17.3)
-      preact: 10.29.2
+      "@docsearch/react": 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
+      preact: 10.29.8
     transitivePeerDependencies:
       - "@algolia/client-search"
       - "@types/react"
+      - preact-render-to-string
       - react
       - react-dom
       - search-insights
 
-  "@docsearch/react@3.8.2(@algolia/client-search@5.55.0)(search-insights@2.17.3)":
+  "@docsearch/react@3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-core": 1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)(search-insights@2.17.3)
-      "@algolia/autocomplete-preset-algolia": 1.17.7(@algolia/client-search@5.55.0)(algoliasearch@5.55.0)
+      "@algolia/autocomplete-core": 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
+      "@algolia/autocomplete-preset-algolia": 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       "@docsearch/css": 3.8.2
-      algoliasearch: 5.55.0
+      algoliasearch: 5.56.0
     optionalDependencies:
       search-insights: 2.17.3
     transitivePeerDependencies:
       - "@algolia/client-search"
-
-  "@emnapi/core@1.11.0":
-    dependencies:
-      "@emnapi/wasi-threads": 1.2.2
-      tslib: 2.8.1
-    optional: true
-
-  "@emnapi/runtime@1.11.0":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  "@emnapi/wasi-threads@1.2.2":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   "@esbuild/aix-ppc64@0.21.5":
     optional: true
@@ -4995,7 +4740,7 @@ snapshots:
   "@esbuild/win32-x64@0.21.5":
     optional: true
 
-  "@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))":
+  "@eslint-community/eslint-utils@4.10.1(eslint@9.39.4(jiti@2.6.1))":
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
@@ -5018,7 +4763,7 @@ snapshots:
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/eslintrc@3.3.5":
+  "@eslint/eslintrc@3.3.6":
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3
@@ -5026,7 +4771,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -5057,7 +4802,7 @@ snapshots:
 
   "@humanwhocodes/retry@0.4.3": {}
 
-  "@iconify-json/simple-icons@1.2.86":
+  "@iconify-json/simple-icons@1.2.93":
     dependencies:
       "@iconify/types": 2.0.0
 
@@ -5085,41 +4830,7 @@ snapshots:
 
   "@keyv/serialize@1.1.1": {}
 
-  "@kriac/commitlint-config@0.7.0(czg@1.13.0)":
-    dependencies:
-      czg: 1.13.0
-
-  "@kriac/eslint-config@0.9.0(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
-    dependencies:
-      "@eslint/js": 9.39.4
-      eslint: 9.39.4(jiti@2.6.1)
-      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-perfectionist: 5.9.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      eslint-plugin-vue: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1)))
-      typescript-eslint: 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
-    transitivePeerDependencies:
-      - "@stylistic/eslint-plugin"
-      - "@typescript-eslint/parser"
-      - supports-color
-      - typescript
-
-  "@kriac/stylelint-config@0.7.0(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2))":
-    dependencies:
-      postcss-html: 1.8.1
-      stylelint: 17.12.0(typescript@5.8.2)
-      stylelint-config-recess-order: 7.7.0(stylelint-order@8.1.1(stylelint@17.12.0(typescript@5.8.2)))(stylelint@17.12.0(typescript@5.8.2))
-      stylelint-config-recommended-vue: 1.6.1(postcss-html@1.8.1)(stylelint@17.12.0(typescript@5.8.2))
-      stylelint-config-standard-scss: 17.0.0(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2))
-      stylelint-order: 8.1.1(stylelint@17.12.0(typescript@5.8.2))
-    transitivePeerDependencies:
-      - postcss
-
-  "@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)":
-    dependencies:
-      "@emnapi/core": 1.11.0
-      "@emnapi/runtime": 1.11.0
-      "@tybys/wasm-util": 0.10.2
+  "@napi-rs/lzma-linux-x64-gnu@1.5.1":
     optional: true
 
   "@nodelib/fs.scandir@2.1.5":
@@ -5134,199 +4845,131 @@ snapshots:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.20.1
 
-  "@oxc-project/types@0.135.0": {}
-
-  "@parcel/watcher-android-arm64@2.5.6":
-    optional: true
-
-  "@parcel/watcher-darwin-arm64@2.5.6":
-    optional: true
-
-  "@parcel/watcher-darwin-x64@2.5.6":
-    optional: true
-
-  "@parcel/watcher-freebsd-x64@2.5.6":
-    optional: true
-
-  "@parcel/watcher-linux-arm-glibc@2.5.6":
-    optional: true
-
-  "@parcel/watcher-linux-arm-musl@2.5.6":
-    optional: true
-
-  "@parcel/watcher-linux-arm64-glibc@2.5.6":
-    optional: true
-
-  "@parcel/watcher-linux-arm64-musl@2.5.6":
-    optional: true
-
-  "@parcel/watcher-linux-x64-glibc@2.5.6":
-    optional: true
-
-  "@parcel/watcher-linux-x64-musl@2.5.6":
-    optional: true
-
-  "@parcel/watcher-win32-arm64@2.5.6":
-    optional: true
-
-  "@parcel/watcher-win32-ia32@2.5.6":
-    optional: true
-
-  "@parcel/watcher-win32-x64@2.5.6":
-    optional: true
-
-  "@parcel/watcher@2.5.6":
-    dependencies:
-      detect-libc: 2.1.2
-      is-glob: 4.0.3
-      node-addon-api: 7.1.1
-      picomatch: 4.0.4
-    optionalDependencies:
-      "@parcel/watcher-android-arm64": 2.5.6
-      "@parcel/watcher-darwin-arm64": 2.5.6
-      "@parcel/watcher-darwin-x64": 2.5.6
-      "@parcel/watcher-freebsd-x64": 2.5.6
-      "@parcel/watcher-linux-arm-glibc": 2.5.6
-      "@parcel/watcher-linux-arm-musl": 2.5.6
-      "@parcel/watcher-linux-arm64-glibc": 2.5.6
-      "@parcel/watcher-linux-arm64-musl": 2.5.6
-      "@parcel/watcher-linux-x64-glibc": 2.5.6
-      "@parcel/watcher-linux-x64-musl": 2.5.6
-      "@parcel/watcher-win32-arm64": 2.5.6
-      "@parcel/watcher-win32-ia32": 2.5.6
-      "@parcel/watcher-win32-x64": 2.5.6
-    optional: true
+  "@oxc-project/types@0.143.0": {}
 
   "@quansync/fs@1.0.0":
     dependencies:
       quansync: 1.0.0
 
-  "@rolldown/binding-android-arm64@1.1.1":
+  "@rolldown/binding-android-arm64@1.2.3":
     optional: true
 
-  "@rolldown/binding-darwin-arm64@1.1.1":
+  "@rolldown/binding-darwin-arm64@1.2.3":
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.1.1":
+  "@rolldown/binding-darwin-x64@1.2.3":
     optional: true
 
-  "@rolldown/binding-freebsd-x64@1.1.1":
+  "@rolldown/binding-freebsd-x64@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.1.1":
+  "@rolldown/binding-linux-arm-gnueabihf@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-arm64-gnu@1.1.1":
+  "@rolldown/binding-linux-arm64-gnu@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.1.1":
+  "@rolldown/binding-linux-arm64-musl@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-ppc64-gnu@1.1.1":
+  "@rolldown/binding-linux-ppc64-gnu@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.1.1":
+  "@rolldown/binding-linux-s390x-gnu@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-x64-gnu@1.1.1":
+  "@rolldown/binding-linux-x64-gnu@1.2.3":
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.1.1":
+  "@rolldown/binding-linux-x64-musl@1.2.3":
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.1.1":
+  "@rolldown/binding-openharmony-arm64@1.2.3":
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.1.1":
-    dependencies:
-      "@emnapi/core": 1.11.0
-      "@emnapi/runtime": 1.11.0
-      "@napi-rs/wasm-runtime": 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+  "@rolldown/binding-win32-arm64-msvc@1.2.3":
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.1.1":
-    optional: true
-
-  "@rolldown/binding-win32-x64-msvc@1.1.1":
+  "@rolldown/binding-win32-x64-msvc@1.2.3":
     optional: true
 
   "@rolldown/pluginutils@1.0.0-rc.13": {}
 
   "@rolldown/pluginutils@1.0.1": {}
 
-  "@rollup/rollup-android-arm-eabi@4.62.0":
+  "@rollup/rollup-android-arm-eabi@4.62.4":
     optional: true
 
-  "@rollup/rollup-android-arm64@4.62.0":
+  "@rollup/rollup-android-arm64@4.62.4":
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.62.0":
+  "@rollup/rollup-darwin-arm64@4.62.4":
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.62.0":
+  "@rollup/rollup-darwin-x64@4.62.4":
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.62.0":
+  "@rollup/rollup-freebsd-arm64@4.62.4":
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.62.0":
+  "@rollup/rollup-freebsd-x64@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.62.0":
+  "@rollup/rollup-linux-arm-gnueabihf@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.62.0":
+  "@rollup/rollup-linux-arm-musleabihf@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.62.0":
+  "@rollup/rollup-linux-arm64-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.62.0":
+  "@rollup/rollup-linux-arm64-musl@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.62.0":
+  "@rollup/rollup-linux-loong64-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-loong64-musl@4.62.0":
+  "@rollup/rollup-linux-loong64-musl@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.62.0":
+  "@rollup/rollup-linux-ppc64-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-musl@4.62.0":
+  "@rollup/rollup-linux-ppc64-musl@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.62.0":
+  "@rollup/rollup-linux-riscv64-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.62.0":
+  "@rollup/rollup-linux-riscv64-musl@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.62.0":
+  "@rollup/rollup-linux-s390x-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.62.0":
+  "@rollup/rollup-linux-x64-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.62.0":
+  "@rollup/rollup-linux-x64-musl@4.62.4":
     optional: true
 
-  "@rollup/rollup-openbsd-x64@4.62.0":
+  "@rollup/rollup-openbsd-x64@4.62.4":
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.62.0":
+  "@rollup/rollup-openharmony-arm64@4.62.4":
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.62.0":
+  "@rollup/rollup-win32-arm64-msvc@4.62.4":
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.62.0":
+  "@rollup/rollup-win32-ia32-msvc@4.62.4":
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.62.0":
+  "@rollup/rollup-win32-x64-gnu@4.62.4":
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.62.0":
+  "@rollup/rollup-win32-x64-msvc@4.62.4":
     optional: true
 
   "@shikijs/core@2.5.0":
@@ -5335,7 +4978,7 @@ snapshots:
       "@shikijs/engine-oniguruma": 2.5.0
       "@shikijs/types": 2.5.0
       "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       hast-util-to-html: 9.0.5
 
   "@shikijs/engine-javascript@2.5.0":
@@ -5365,7 +5008,7 @@ snapshots:
   "@shikijs/types@2.5.0":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
 
   "@shikijs/vscode-textmate@10.0.2": {}
 
@@ -5377,16 +5020,11 @@ snapshots:
 
   "@sindresorhus/merge-streams@4.0.0": {}
 
-  "@tybys/wasm-util@0.10.2":
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   "@types/esrecurse@4.3.1": {}
 
   "@types/estree@1.0.9": {}
 
-  "@types/hast@3.0.4":
+  "@types/hast@3.0.5":
     dependencies:
       "@types/unist": 3.0.3
 
@@ -5415,57 +5053,57 @@ snapshots:
 
   "@types/web-bluetooth@0.0.21": {}
 
-  "@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
+  "@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      "@typescript-eslint/scope-manager": 8.61.1
-      "@typescript-eslint/type-utils": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      "@typescript-eslint/utils": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      "@typescript-eslint/visitor-keys": 8.61.1
+      "@typescript-eslint/parser": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/scope-manager": 8.66.0
+      "@typescript-eslint/type-utils": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/utils": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/visitor-keys": 8.66.0
       eslint: 9.39.4(jiti@2.6.1)
-      ignore: 7.0.5
+      ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.8.2)
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
+  "@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.61.1
-      "@typescript-eslint/types": 8.61.1
-      "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.8.2)
-      "@typescript-eslint/visitor-keys": 8.61.1
+      "@typescript-eslint/scope-manager": 8.66.0
+      "@typescript-eslint/types": 8.66.0
+      "@typescript-eslint/typescript-estree": 8.66.0(typescript@5.8.2)
+      "@typescript-eslint/visitor-keys": 8.66.0
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.61.1(typescript@5.8.2)":
+  "@typescript-eslint/project-service@8.66.0(typescript@5.8.2)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@5.8.2)
-      "@typescript-eslint/types": 8.61.1
+      "@typescript-eslint/tsconfig-utils": 8.66.0(typescript@5.8.2)
+      "@typescript-eslint/types": 8.66.0
       debug: 4.4.3
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.61.1":
+  "@typescript-eslint/scope-manager@8.66.0":
     dependencies:
-      "@typescript-eslint/types": 8.61.1
-      "@typescript-eslint/visitor-keys": 8.61.1
+      "@typescript-eslint/types": 8.66.0
+      "@typescript-eslint/visitor-keys": 8.66.0
 
-  "@typescript-eslint/tsconfig-utils@8.61.1(typescript@5.8.2)":
+  "@typescript-eslint/tsconfig-utils@8.66.0(typescript@5.8.2)":
     dependencies:
       typescript: 5.8.2
 
-  "@typescript-eslint/type-utils@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
+  "@typescript-eslint/type-utils@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
     dependencies:
-      "@typescript-eslint/types": 8.61.1
-      "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.8.2)
-      "@typescript-eslint/utils": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/types": 8.66.0
+      "@typescript-eslint/typescript-estree": 8.66.0(typescript@5.8.2)
+      "@typescript-eslint/utils": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
       debug: 4.4.3
       eslint: 9.39.4(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.8.2)
@@ -5473,44 +5111,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.61.1": {}
+  "@typescript-eslint/types@8.66.0": {}
 
-  "@typescript-eslint/typescript-estree@8.61.1(typescript@5.8.2)":
+  "@typescript-eslint/typescript-estree@8.66.0(typescript@5.8.2)":
     dependencies:
-      "@typescript-eslint/project-service": 8.61.1(typescript@5.8.2)
-      "@typescript-eslint/tsconfig-utils": 8.61.1(typescript@5.8.2)
-      "@typescript-eslint/types": 8.61.1
-      "@typescript-eslint/visitor-keys": 8.61.1
+      "@typescript-eslint/project-service": 8.66.0(typescript@5.8.2)
+      "@typescript-eslint/tsconfig-utils": 8.66.0(typescript@5.8.2)
+      "@typescript-eslint/types": 8.66.0
+      "@typescript-eslint/visitor-keys": 8.66.0
       debug: 4.4.3
-      minimatch: 10.2.5
-      semver: 7.8.4
+      minimatch: 10.2.6
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.8.2)
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
+  "@typescript-eslint/utils@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4(jiti@2.6.1))
-      "@typescript-eslint/scope-manager": 8.61.1
-      "@typescript-eslint/types": 8.61.1
-      "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.8.2)
+      "@eslint-community/eslint-utils": 4.10.1(eslint@9.39.4(jiti@2.6.1))
+      "@typescript-eslint/scope-manager": 8.66.0
+      "@typescript-eslint/types": 8.66.0
+      "@typescript-eslint/typescript-estree": 8.66.0(typescript@5.8.2)
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.61.1":
+  "@typescript-eslint/visitor-keys@8.66.0":
     dependencies:
-      "@typescript-eslint/types": 8.61.1
+      "@typescript-eslint/types": 8.66.0
       eslint-visitor-keys: 5.0.1
 
-  "@ungap/structured-clone@1.3.1": {}
+  "@ungap/structured-clone@1.3.3": {}
 
-  "@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.6.0)(sass@1.101.0))(vue@3.5.32(typescript@5.8.2))":
+  "@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.6.0)(sass@1.78.0))(vue@3.5.32(typescript@5.8.2))":
     dependencies:
-      vite: 5.4.21(@types/node@25.6.0)(sass@1.101.0)
+      vite: 5.4.21(@types/node@25.6.0)(sass@1.78.0)
       vue: 3.5.32(typescript@5.8.2)
 
   "@vitejs/plugin-vue@6.0.6(vite@5.4.21(@types/node@25.6.0)(sass@1.78.0))(vue@3.5.32(typescript@5.8.2))":
@@ -5533,7 +5171,7 @@ snapshots:
 
   "@vue/compiler-core@3.5.13":
     dependencies:
-      "@babel/parser": 7.29.7
+      "@babel/parser": 7.29.8
       "@vue/shared": 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -5541,16 +5179,16 @@ snapshots:
 
   "@vue/compiler-core@3.5.32":
     dependencies:
-      "@babel/parser": 7.29.7
+      "@babel/parser": 7.29.8
       "@vue/shared": 3.5.32
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  "@vue/compiler-core@3.5.38":
+  "@vue/compiler-core@3.5.41":
     dependencies:
-      "@babel/parser": 7.29.7
-      "@vue/shared": 3.5.38
+      "@babel/parser": 7.29.8
+      "@vue/shared": 3.5.41
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
@@ -5565,33 +5203,33 @@ snapshots:
       "@vue/compiler-core": 3.5.32
       "@vue/shared": 3.5.32
 
-  "@vue/compiler-dom@3.5.38":
+  "@vue/compiler-dom@3.5.41":
     dependencies:
-      "@vue/compiler-core": 3.5.38
-      "@vue/shared": 3.5.38
+      "@vue/compiler-core": 3.5.41
+      "@vue/shared": 3.5.41
 
   "@vue/compiler-sfc@3.5.13":
     dependencies:
-      "@babel/parser": 7.29.7
+      "@babel/parser": 7.29.8
       "@vue/compiler-core": 3.5.13
       "@vue/compiler-dom": 3.5.13
       "@vue/compiler-ssr": 3.5.13
       "@vue/shared": 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   "@vue/compiler-sfc@3.5.32":
     dependencies:
-      "@babel/parser": 7.29.7
+      "@babel/parser": 7.29.8
       "@vue/compiler-core": 3.5.32
       "@vue/compiler-dom": 3.5.32
       "@vue/compiler-ssr": 3.5.32
       "@vue/shared": 3.5.32
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.15
+      postcss: 8.5.26
       source-map-js: 1.2.1
 
   "@vue/compiler-ssr@3.5.13":
@@ -5604,13 +5242,13 @@ snapshots:
       "@vue/compiler-dom": 3.5.32
       "@vue/shared": 3.5.32
 
-  "@vue/devtools-api@7.7.9":
+  "@vue/devtools-api@7.7.10":
     dependencies:
-      "@vue/devtools-kit": 7.7.9
+      "@vue/devtools-kit": 7.7.10
 
-  "@vue/devtools-kit@7.7.9":
+  "@vue/devtools-kit@7.7.10":
     dependencies:
-      "@vue/devtools-shared": 7.7.9
+      "@vue/devtools-shared": 7.7.10
       birpc: 2.9.0
       hookable: 5.5.3
       mitt: 3.0.1
@@ -5618,19 +5256,19 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.6
 
-  "@vue/devtools-shared@7.7.9":
+  "@vue/devtools-shared@7.7.10":
     dependencies:
       rfdc: 1.4.1
 
   "@vue/language-core@3.2.1":
     dependencies:
       "@volar/language-core": 2.4.27
-      "@vue/compiler-dom": 3.5.38
-      "@vue/shared": 3.5.38
+      "@vue/compiler-dom": 3.5.41
+      "@vue/shared": 3.5.41
       alien-signals: 3.2.1
       muggle-string: 0.4.1
       path-browserify: 1.0.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   "@vue/reactivity@3.5.13":
     dependencies:
@@ -5680,7 +5318,7 @@ snapshots:
 
   "@vue/shared@3.5.32": {}
 
-  "@vue/shared@3.5.38": {}
+  "@vue/shared@3.5.41": {}
 
   "@vueuse/core@12.8.2(typescript@5.8.2)":
     dependencies:
@@ -5709,11 +5347,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  acorn-jsx@5.3.2(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
-  acorn@8.17.0: {}
+  acorn@8.18.0: {}
 
   ajv@6.15.0:
     dependencies:
@@ -5725,26 +5363,26 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  algoliasearch@5.55.0:
+  algoliasearch@5.56.0:
     dependencies:
-      "@algolia/abtesting": 1.21.0
-      "@algolia/client-abtesting": 5.55.0
-      "@algolia/client-analytics": 5.55.0
-      "@algolia/client-common": 5.55.0
-      "@algolia/client-insights": 5.55.0
-      "@algolia/client-personalization": 5.55.0
-      "@algolia/client-query-suggestions": 5.55.0
-      "@algolia/client-search": 5.55.0
-      "@algolia/ingestion": 1.55.0
-      "@algolia/monitoring": 1.55.0
-      "@algolia/recommend": 5.55.0
-      "@algolia/requester-browser-xhr": 5.55.0
-      "@algolia/requester-fetch": 5.55.0
-      "@algolia/requester-node-http": 5.55.0
+      "@algolia/abtesting": 1.22.0
+      "@algolia/client-abtesting": 5.56.0
+      "@algolia/client-analytics": 5.56.0
+      "@algolia/client-common": 5.56.0
+      "@algolia/client-insights": 5.56.0
+      "@algolia/client-personalization": 5.56.0
+      "@algolia/client-query-suggestions": 5.56.0
+      "@algolia/client-search": 5.56.0
+      "@algolia/ingestion": 1.56.0
+      "@algolia/monitoring": 1.56.0
+      "@algolia/recommend": 5.56.0
+      "@algolia/requester-browser-xhr": 5.56.0
+      "@algolia/requester-fetch": 5.56.0
+      "@algolia/requester-node-http": 5.56.0
 
   alien-signals@3.2.1: {}
 
@@ -5775,7 +5413,7 @@ snapshots:
 
   ast-kit@3.0.0:
     dependencies:
-      "@babel/parser": 8.0.0
+      "@babel/parser": 8.0.4
       estree-walker: 3.0.3
       pathe: 2.0.3
 
@@ -5793,12 +5431,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5808,10 +5446,10 @@ snapshots:
 
   cac@7.0.0: {}
 
-  cacheable@2.3.5:
+  cacheable@2.5.0:
     dependencies:
-      "@cacheable/memory": 2.0.9
-      "@cacheable/utils": 2.4.1
+      "@cacheable/memory": 2.2.0
+      "@cacheable/utils": 2.5.0
       hookified: 1.15.1
       keyv: 5.6.0
       qified: 0.10.1
@@ -5841,11 +5479,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chokidar@5.0.0:
-    dependencies:
-      readdirp: 5.0.0
-    optional: true
-
   cli-cursor@5.0.0:
     dependencies:
       restore-cursor: 5.1.0
@@ -5853,7 +5486,7 @@ snapshots:
   cli-truncate@5.2.0:
     dependencies:
       slice-ansi: 8.0.0
-      string-width: 8.2.1
+      string-width: 8.2.2
 
   cliui@8.0.1:
     dependencies:
@@ -5916,7 +5549,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.8.2
@@ -5949,9 +5582,6 @@ snapshots:
   defu@6.1.7: {}
 
   dequal@2.0.3: {}
-
-  detect-libc@2.1.2:
-    optional: true
 
   devlop@1.1.0:
     dependencies:
@@ -6001,7 +5631,7 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-toolkit@1.47.1: {}
+  es-toolkit@1.50.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -6037,27 +5667,27 @@ snapshots:
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
 
-  eslint-plugin-perfectionist@5.9.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2):
+  eslint-plugin-perfectionist@5.10.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2):
     dependencies:
-      "@typescript-eslint/utils": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/utils": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
       eslint: 9.39.4(jiti@2.6.1)
       natural-orderby: 5.0.0
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1))):
+  eslint-plugin-vue@10.10.0(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(vue-eslint-parser@10.4.0(eslint@9.39.4(jiti@2.6.1))):
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      "@eslint-community/eslint-utils": 4.10.1(eslint@9.39.4(jiti@2.6.1))
       eslint: 9.39.4(jiti@2.6.1)
       natural-compare: 1.4.0
       nth-check: 2.1.1
-      postcss-selector-parser: 7.1.4
-      semver: 7.8.4
+      postcss-selector-parser: 7.1.5
+      semver: 7.8.5
       vue-eslint-parser: 10.4.0(eslint@9.39.4(jiti@2.6.1))
-      xml-name-validator: 4.0.0
+      xml-name-validator: 5.0.0
     optionalDependencies:
-      "@typescript-eslint/parser": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/parser": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -6079,12 +5709,12 @@ snapshots:
 
   eslint@9.39.4(jiti@2.6.1):
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@9.39.4(jiti@2.6.1))
+      "@eslint-community/eslint-utils": 4.10.1(eslint@9.39.4(jiti@2.6.1))
       "@eslint-community/regexpp": 4.12.2
       "@eslint/config-array": 0.21.2
       "@eslint/config-helpers": 0.4.2
       "@eslint/core": 0.17.0
-      "@eslint/eslintrc": 3.3.5
+      "@eslint/eslintrc": 3.3.6
       "@eslint/js": 9.39.4
       "@eslint/plugin-kit": 0.4.1
       "@humanfs/node": 0.16.8
@@ -6120,14 +5750,14 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
@@ -6164,7 +5794,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastest-levenshtein@1.0.16: {}
 
@@ -6172,13 +5802,13 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
-  file-entry-cache@11.1.3:
+  file-entry-cache@11.1.5:
     dependencies:
-      flat-cache: 6.1.22
+      flat-cache: 6.1.23
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6195,20 +5825,20 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.2
+      flatted: 3.4.4
       keyv: 4.5.4
 
-  flat-cache@6.1.22:
+  flat-cache@6.1.23:
     dependencies:
-      cacheable: 2.3.5
-      flatted: 3.4.2
+      cacheable: 2.5.0
+      flatted: 3.4.4
       hookified: 1.15.1
 
-  flatted@3.4.2: {}
+  flatted@3.4.4: {}
 
   focus-trap@7.8.0:
     dependencies:
-      tabbable: 6.4.0
+      tabbable: 6.5.0
 
   fsevents@2.3.3:
     optional: true
@@ -6253,11 +5883,11 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globby@16.2.0:
+  globby@16.2.3:
     dependencies:
       "@sindresorhus/merge-streams": 4.0.0
       fast-glob: 3.3.3
-      ignore: 7.0.5
+      ignore: 7.0.6
       is-path-inside: 4.0.0
       slash: 5.1.0
       unicorn-magic: 0.4.0
@@ -6274,7 +5904,7 @@ snapshots:
 
   hast-util-to-html@9.0.5:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/unist": 3.0.3
       ccount: 2.0.1
       comma-separated-tokens: 2.0.3
@@ -6288,7 +5918,7 @@ snapshots:
 
   hast-util-whitespace@3.0.0:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
 
   hookable@5.5.3: {}
 
@@ -6302,7 +5932,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  htmlparser2@8.0.2:
+  htmlparser2@9.1.0:
     dependencies:
       domelementtype: 2.3.0
       domhandler: 5.0.3
@@ -6313,12 +5943,9 @@ snapshots:
 
   ignore@5.3.2: {}
 
-  ignore@7.0.5: {}
+  ignore@7.0.6: {}
 
   immutable@4.3.9: {}
-
-  immutable@5.1.6:
-    optional: true
 
   import-fresh@3.3.1:
     dependencies:
@@ -6373,7 +6000,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6412,9 +6039,9 @@ snapshots:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       string-argv: 0.3.2
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       yaml: 2.9.0
 
   listr2@9.0.5:
@@ -6452,9 +6079,9 @@ snapshots:
 
   mdast-util-to-hast@13.2.1:
     dependencies:
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.1
+      "@ungap/structured-clone": 1.3.3
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -6494,13 +6121,13 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -6512,14 +6139,11 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
   natural-orderby@5.0.0: {}
-
-  node-addon-api@7.1.1:
-    optional: true
 
   normalize-path@3.0.0: {}
 
@@ -6527,7 +6151,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  obug@2.1.3: {}
+  obug@2.1.4: {}
 
   onetime@7.0.0:
     dependencies:
@@ -6581,49 +6205,45 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
-  postcss-html@1.8.1:
+  postcss-html@2.0.0(postcss@8.5.26):
     dependencies:
-      htmlparser2: 8.0.2
+      htmlparser2: 9.1.0
       js-tokens: 9.0.1
-      postcss: 8.5.15
-      postcss-safe-parser: 6.0.0(postcss@8.5.15)
+      postcss: 8.5.26
+      postcss-safe-parser: 7.0.1(postcss@8.5.26)
 
   postcss-media-query-parser@0.2.3: {}
 
   postcss-resolve-nested-selector@0.1.6: {}
 
-  postcss-safe-parser@6.0.0(postcss@8.5.15):
+  postcss-safe-parser@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
 
-  postcss-safe-parser@7.0.1(postcss@8.5.15):
+  postcss-scss@4.0.9(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
 
-  postcss-scss@4.0.9(postcss@8.5.15):
-    dependencies:
-      postcss: 8.5.15
-
-  postcss-selector-parser@7.1.4:
+  postcss-selector-parser@7.1.5:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sorting@10.0.0(postcss@8.5.15):
+  postcss-sorting@10.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  preact@10.29.2: {}
+  preact@10.29.8: {}
 
   prelude-ls@1.2.1: {}
 
@@ -6644,9 +6264,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
-
-  readdirp@5.0.0:
-    optional: true
 
   regex-recursion@6.0.2:
     dependencies:
@@ -6677,7 +6294,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.25.2(rolldown@1.1.1)(typescript@5.8.2)(vue-tsc@3.2.1(typescript@5.8.2)):
+  rolldown-plugin-dts@0.25.2(rolldown@1.2.3)(typescript@5.8.2)(vue-tsc@3.2.1(typescript@5.8.2)):
     dependencies:
       "@babel/generator": 8.0.0-rc.6
       "@babel/helper-validator-identifier": 8.0.0-rc.6
@@ -6686,78 +6303,69 @@ snapshots:
       birpc: 4.0.0
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
-      obug: 2.1.3
-      rolldown: 1.1.1
+      obug: 2.1.4
+      rolldown: 1.2.3
     optionalDependencies:
       typescript: 5.8.2
       vue-tsc: 3.2.1(typescript@5.8.2)
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.1.1:
+  rolldown@1.2.3:
     dependencies:
-      "@oxc-project/types": 0.135.0
+      "@oxc-project/types": 0.143.0
       "@rolldown/pluginutils": 1.0.1
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.1.1
-      "@rolldown/binding-darwin-arm64": 1.1.1
-      "@rolldown/binding-darwin-x64": 1.1.1
-      "@rolldown/binding-freebsd-x64": 1.1.1
-      "@rolldown/binding-linux-arm-gnueabihf": 1.1.1
-      "@rolldown/binding-linux-arm64-gnu": 1.1.1
-      "@rolldown/binding-linux-arm64-musl": 1.1.1
-      "@rolldown/binding-linux-ppc64-gnu": 1.1.1
-      "@rolldown/binding-linux-s390x-gnu": 1.1.1
-      "@rolldown/binding-linux-x64-gnu": 1.1.1
-      "@rolldown/binding-linux-x64-musl": 1.1.1
-      "@rolldown/binding-openharmony-arm64": 1.1.1
-      "@rolldown/binding-wasm32-wasi": 1.1.1
-      "@rolldown/binding-win32-arm64-msvc": 1.1.1
-      "@rolldown/binding-win32-x64-msvc": 1.1.1
+      "@rolldown/binding-android-arm64": 1.2.3
+      "@rolldown/binding-darwin-arm64": 1.2.3
+      "@rolldown/binding-darwin-x64": 1.2.3
+      "@rolldown/binding-freebsd-x64": 1.2.3
+      "@rolldown/binding-linux-arm-gnueabihf": 1.2.3
+      "@rolldown/binding-linux-arm64-gnu": 1.2.3
+      "@rolldown/binding-linux-arm64-musl": 1.2.3
+      "@rolldown/binding-linux-ppc64-gnu": 1.2.3
+      "@rolldown/binding-linux-s390x-gnu": 1.2.3
+      "@rolldown/binding-linux-x64-gnu": 1.2.3
+      "@rolldown/binding-linux-x64-musl": 1.2.3
+      "@rolldown/binding-openharmony-arm64": 1.2.3
+      "@rolldown/binding-win32-arm64-msvc": 1.2.3
+      "@rolldown/binding-win32-x64-msvc": 1.2.3
 
-  rollup@4.62.0:
+  rollup@4.62.4:
     dependencies:
       "@types/estree": 1.0.9
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.62.0
-      "@rollup/rollup-android-arm64": 4.62.0
-      "@rollup/rollup-darwin-arm64": 4.62.0
-      "@rollup/rollup-darwin-x64": 4.62.0
-      "@rollup/rollup-freebsd-arm64": 4.62.0
-      "@rollup/rollup-freebsd-x64": 4.62.0
-      "@rollup/rollup-linux-arm-gnueabihf": 4.62.0
-      "@rollup/rollup-linux-arm-musleabihf": 4.62.0
-      "@rollup/rollup-linux-arm64-gnu": 4.62.0
-      "@rollup/rollup-linux-arm64-musl": 4.62.0
-      "@rollup/rollup-linux-loong64-gnu": 4.62.0
-      "@rollup/rollup-linux-loong64-musl": 4.62.0
-      "@rollup/rollup-linux-ppc64-gnu": 4.62.0
-      "@rollup/rollup-linux-ppc64-musl": 4.62.0
-      "@rollup/rollup-linux-riscv64-gnu": 4.62.0
-      "@rollup/rollup-linux-riscv64-musl": 4.62.0
-      "@rollup/rollup-linux-s390x-gnu": 4.62.0
-      "@rollup/rollup-linux-x64-gnu": 4.62.0
-      "@rollup/rollup-linux-x64-musl": 4.62.0
-      "@rollup/rollup-openbsd-x64": 4.62.0
-      "@rollup/rollup-openharmony-arm64": 4.62.0
-      "@rollup/rollup-win32-arm64-msvc": 4.62.0
-      "@rollup/rollup-win32-ia32-msvc": 4.62.0
-      "@rollup/rollup-win32-x64-gnu": 4.62.0
-      "@rollup/rollup-win32-x64-msvc": 4.62.0
+      "@napi-rs/lzma-linux-x64-gnu": 1.5.1
+      "@rollup/rollup-android-arm-eabi": 4.62.4
+      "@rollup/rollup-android-arm64": 4.62.4
+      "@rollup/rollup-darwin-arm64": 4.62.4
+      "@rollup/rollup-darwin-x64": 4.62.4
+      "@rollup/rollup-freebsd-arm64": 4.62.4
+      "@rollup/rollup-freebsd-x64": 4.62.4
+      "@rollup/rollup-linux-arm-gnueabihf": 4.62.4
+      "@rollup/rollup-linux-arm-musleabihf": 4.62.4
+      "@rollup/rollup-linux-arm64-gnu": 4.62.4
+      "@rollup/rollup-linux-arm64-musl": 4.62.4
+      "@rollup/rollup-linux-loong64-gnu": 4.62.4
+      "@rollup/rollup-linux-loong64-musl": 4.62.4
+      "@rollup/rollup-linux-ppc64-gnu": 4.62.4
+      "@rollup/rollup-linux-ppc64-musl": 4.62.4
+      "@rollup/rollup-linux-riscv64-gnu": 4.62.4
+      "@rollup/rollup-linux-riscv64-musl": 4.62.4
+      "@rollup/rollup-linux-s390x-gnu": 4.62.4
+      "@rollup/rollup-linux-x64-gnu": 4.62.4
+      "@rollup/rollup-linux-x64-musl": 4.62.4
+      "@rollup/rollup-openbsd-x64": 4.62.4
+      "@rollup/rollup-openharmony-arm64": 4.62.4
+      "@rollup/rollup-win32-arm64-msvc": 4.62.4
+      "@rollup/rollup-win32-ia32-msvc": 4.62.4
+      "@rollup/rollup-win32-x64-gnu": 4.62.4
+      "@rollup/rollup-win32-x64-msvc": 4.62.4
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
-
-  sass@1.101.0:
-    dependencies:
-      chokidar: 5.0.0
-      immutable: 5.1.6
-      source-map-js: 1.2.1
-    optionalDependencies:
-      "@parcel/watcher": 2.5.6
-    optional: true
 
   sass@1.78.0:
     dependencies:
@@ -6767,7 +6375,7 @@ snapshots:
 
   search-insights@2.17.3: {}
 
-  semver@7.8.4: {}
+  semver@7.8.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -6784,7 +6392,7 @@ snapshots:
       "@shikijs/themes": 2.5.0
       "@shikijs/types": 2.5.0
       "@shikijs/vscode-textmate": 10.0.2
-      "@types/hast": 3.0.4
+      "@types/hast": 3.0.5
 
   signal-exit@4.1.0: {}
 
@@ -6826,7 +6434,7 @@ snapshots:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
-  string-width@8.2.1:
+  string-width@8.2.2:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
@@ -6846,9 +6454,9 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  stylelint-config-html@1.1.0(postcss-html@1.8.1)(stylelint@17.12.0(typescript@5.8.2)):
+  stylelint-config-html@2.0.0(postcss-html@2.0.0(postcss@8.5.26))(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
-      postcss-html: 1.8.1
+      postcss-html: 2.0.0(postcss@8.5.26)
       stylelint: 17.12.0(typescript@5.8.2)
 
   stylelint-config-recess-order@7.7.0(stylelint-order@8.1.1(stylelint@17.12.0(typescript@5.8.2)))(stylelint@17.12.0(typescript@5.8.2)):
@@ -6856,34 +6464,36 @@ snapshots:
       stylelint: 17.12.0(typescript@5.8.2)
       stylelint-order: 8.1.1(stylelint@17.12.0(typescript@5.8.2))
 
-  stylelint-config-recommended-scss@17.0.1(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2)):
+  stylelint-config-recommended-scss@17.0.1(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
-      postcss-scss: 4.0.9(postcss@8.5.15)
+      postcss-scss: 4.0.9(postcss@8.5.26)
       stylelint: 17.12.0(typescript@5.8.2)
       stylelint-config-recommended: 18.0.0(stylelint@17.12.0(typescript@5.8.2))
       stylelint-scss: 7.2.0(stylelint@17.12.0(typescript@5.8.2))
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
 
-  stylelint-config-recommended-vue@1.6.1(postcss-html@1.8.1)(stylelint@17.12.0(typescript@5.8.2)):
+  stylelint-config-recommended-vue@2.0.0(postcss-html@2.0.0(postcss@8.5.26))(stylelint-config-html@2.0.0(postcss-html@2.0.0(postcss@8.5.26))(stylelint@17.12.0(typescript@5.8.2)))(stylelint-config-recommended-scss@17.0.1(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2)))(stylelint-config-recommended@18.0.0(stylelint@17.12.0(typescript@5.8.2)))(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
-      postcss-html: 1.8.1
-      semver: 7.8.4
+      postcss-html: 2.0.0(postcss@8.5.26)
+      semver: 7.8.5
       stylelint: 17.12.0(typescript@5.8.2)
-      stylelint-config-html: 1.1.0(postcss-html@1.8.1)(stylelint@17.12.0(typescript@5.8.2))
+      stylelint-config-html: 2.0.0(postcss-html@2.0.0(postcss@8.5.26))(stylelint@17.12.0(typescript@5.8.2))
       stylelint-config-recommended: 18.0.0(stylelint@17.12.0(typescript@5.8.2))
+    optionalDependencies:
+      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2))
 
   stylelint-config-recommended@18.0.0(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
       stylelint: 17.12.0(typescript@5.8.2)
 
-  stylelint-config-standard-scss@17.0.0(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2)):
+  stylelint-config-standard-scss@17.0.0(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
       stylelint: 17.12.0(typescript@5.8.2)
-      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.15)(stylelint@17.12.0(typescript@5.8.2))
+      stylelint-config-recommended-scss: 17.0.1(postcss@8.5.26)(stylelint@17.12.0(typescript@5.8.2))
       stylelint-config-standard: 40.0.0(stylelint@17.12.0(typescript@5.8.2))
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
 
   stylelint-config-standard@40.0.0(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
@@ -6892,34 +6502,34 @@ snapshots:
 
   stylelint-order@8.1.1(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
-      postcss: 8.5.15
-      postcss-sorting: 10.0.0(postcss@8.5.15)
+      postcss: 8.5.26
+      postcss-sorting: 10.0.0(postcss@8.5.26)
       stylelint: 17.12.0(typescript@5.8.2)
 
   stylelint-scss@7.2.0(stylelint@17.12.0(typescript@5.8.2)):
     dependencies:
-      "@csstools/css-calc": 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-calc": 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
-      "@csstools/css-syntax-patches-for-csstree": 1.1.5(css-tree@3.2.1)
+      "@csstools/css-syntax-patches-for-csstree": 1.1.7(css-tree@3.2.1)
       "@csstools/css-tokenizer": 4.0.0
       css-tree: 3.2.1
       is-plain-object: 5.0.0
       known-css-properties: 0.37.0
       postcss-media-query-parser: 0.2.3
       postcss-resolve-nested-selector: 0.1.6
-      postcss-selector-parser: 7.1.4
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
       stylelint: 17.12.0(typescript@5.8.2)
 
   stylelint@17.12.0(typescript@5.8.2):
     dependencies:
-      "@csstools/css-calc": 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-calc": 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
-      "@csstools/css-syntax-patches-for-csstree": 1.1.5(css-tree@3.2.1)
+      "@csstools/css-syntax-patches-for-csstree": 1.1.7(css-tree@3.2.1)
       "@csstools/css-tokenizer": 4.0.0
       "@csstools/media-query-list-parser": 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      "@csstools/selector-resolve-nested": 4.0.0(postcss-selector-parser@7.1.4)
-      "@csstools/selector-specificity": 6.0.0(postcss-selector-parser@7.1.4)
+      "@csstools/selector-resolve-nested": 4.0.1(postcss-selector-parser@7.1.5)
+      "@csstools/selector-specificity": 6.0.0(postcss-selector-parser@7.1.5)
       colord: 2.9.3
       cosmiconfig: 9.0.2(typescript@5.8.2)
       css-functions-list: 3.3.3
@@ -6927,24 +6537,24 @@ snapshots:
       debug: 4.4.3
       fast-glob: 3.3.3
       fastest-levenshtein: 1.0.16
-      file-entry-cache: 11.1.3
+      file-entry-cache: 11.1.5
       global-modules: 2.0.0
-      globby: 16.2.0
+      globby: 16.2.3
       globjoin: 0.1.4
       html-tags: 5.1.0
-      ignore: 7.0.5
+      ignore: 7.0.6
       import-meta-resolve: 4.2.0
       mathml-tag-names: 4.0.0
       meow: 14.1.0
       micromatch: 4.0.8
       normalize-path: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-safe-parser: 7.0.1(postcss@8.5.15)
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-safe-parser: 7.0.1(postcss@8.5.26)
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
-      string-width: 8.2.1
-      supports-hyperlinks: 4.4.0
+      string-width: 8.2.2
+      supports-hyperlinks: 4.5.0
       svg-tags: 1.0.0
       table: 6.9.0
       write-file-atomic: 7.0.1
@@ -6962,14 +6572,14 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-hyperlinks@4.4.0:
+  supports-hyperlinks@4.5.0:
     dependencies:
       has-flag: 5.0.1
       supports-color: 10.2.2
 
   svg-tags@1.0.0: {}
 
-  tabbable@6.4.0: {}
+  tabbable@6.5.0: {}
 
   table@6.9.0:
     dependencies:
@@ -6979,12 +6589,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7006,12 +6616,12 @@ snapshots:
       empathic: 2.0.1
       hookable: 6.1.1
       import-without-cache: 0.4.0
-      obug: 2.1.3
-      picomatch: 4.0.4
-      rolldown: 1.1.1
-      rolldown-plugin-dts: 0.25.2(rolldown@1.1.1)(typescript@5.8.2)(vue-tsc@3.2.1(typescript@5.8.2))
-      semver: 7.8.4
-      tinyexec: 1.2.4
+      obug: 2.1.4
+      picomatch: 4.0.5
+      rolldown: 1.2.3
+      rolldown-plugin-dts: 0.25.2(rolldown@1.2.3)(typescript@5.8.2)(vue-tsc@3.2.1(typescript@5.8.2))
+      semver: 7.8.5
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
@@ -7023,19 +6633,16 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tslib@2.8.1:
-    optional: true
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2):
+  typescript-eslint@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.61.1(@typescript-eslint/parser@8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      "@typescript-eslint/parser": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
-      "@typescript-eslint/typescript-estree": 8.61.1(typescript@5.8.2)
-      "@typescript-eslint/utils": 8.61.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/eslint-plugin": 8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/parser": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
+      "@typescript-eslint/typescript-estree": 8.66.0(typescript@5.8.2)
+      "@typescript-eslint/utils": 8.66.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.2)
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -7091,48 +6698,38 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@5.4.21(@types/node@25.6.0)(sass@1.101.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.15
-      rollup: 4.62.0
-    optionalDependencies:
-      "@types/node": 25.6.0
-      fsevents: 2.3.3
-      sass: 1.101.0
-
   vite@5.4.21(@types/node@25.6.0)(sass@1.78.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.15
-      rollup: 4.62.0
+      postcss: 8.5.26
+      rollup: 4.62.4
     optionalDependencies:
       "@types/node": 25.6.0
       fsevents: 2.3.3
       sass: 1.78.0
 
-  vitepress@1.6.4(@algolia/client-search@5.55.0)(@types/node@25.6.0)(postcss@8.5.15)(sass@1.101.0)(search-insights@2.17.3)(typescript@5.8.2):
+  vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@25.6.0)(postcss@8.5.26)(sass@1.78.0)(search-insights@2.17.3)(typescript@5.8.2):
     dependencies:
       "@docsearch/css": 3.8.2
-      "@docsearch/js": 3.8.2(@algolia/client-search@5.55.0)(search-insights@2.17.3)
-      "@iconify-json/simple-icons": 1.2.86
+      "@docsearch/js": 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
+      "@iconify-json/simple-icons": 1.2.93
       "@shikijs/core": 2.5.0
       "@shikijs/transformers": 2.5.0
       "@shikijs/types": 2.5.0
       "@types/markdown-it": 14.1.2
-      "@vitejs/plugin-vue": 5.2.4(vite@5.4.21(@types/node@25.6.0)(sass@1.101.0))(vue@3.5.32(typescript@5.8.2))
-      "@vue/devtools-api": 7.7.9
-      "@vue/shared": 3.5.38
+      "@vitejs/plugin-vue": 5.2.4(vite@5.4.21(@types/node@25.6.0)(sass@1.78.0))(vue@3.5.32(typescript@5.8.2))
+      "@vue/devtools-api": 7.7.10
+      "@vue/shared": 3.5.41
       "@vueuse/core": 12.8.2(typescript@5.8.2)
       "@vueuse/integrations": 12.8.2(focus-trap@7.8.0)(typescript@5.8.2)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 2.5.0
-      vite: 5.4.21(@types/node@25.6.0)(sass@1.101.0)
+      vite: 5.4.21(@types/node@25.6.0)(sass@1.78.0)
       vue: 3.5.32(typescript@5.8.2)
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.26
     transitivePeerDependencies:
       - "@algolia/client-search"
       - "@types/node"
@@ -7147,6 +6744,7 @@ snapshots:
       - less
       - lightningcss
       - nprogress
+      - preact-render-to-string
       - qrcode
       - react
       - react-dom
@@ -7170,7 +6768,7 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
       esquery: 1.7.0
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
@@ -7226,7 +6824,7 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
-  xml-name-validator@4.0.0: {}
+  xml-name-validator@5.0.0: {}
 
   y18n@5.0.8: {}
 
@@ -7234,7 +6832,7 @@ snapshots:
 
   yargs-parser@21.1.1: {}
 
-  yargs@17.7.2:
+  yargs@17.7.3:
     dependencies:
       cliui: 8.0.1
       escalade: 3.2.0

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,3 +1,3 @@
 export default {
-  extends: ["@kriac/stylelint-config"],
+  extends: ["@kriac/lint-kit/stylelint"],
 };


### PR DESCRIPTION
## 📋 变更说明

请简要说明本次 PR 做了什么：

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 重构
- [ ] 代码风格优化
- [ ] 文档更新
- [ ] 测试用例
- [ ] 其他

## 📝 更新日志

<!--
1. 关闭 Issue 请使用 `Fixes #xxx`
-->

- fix: 移除 pnpm `shamefully-hoist` 后，加载配置时提示找不到 `stylelint-order`、`stylelint-config-standard-scss` 等依赖的问题
- chore: 更新依赖关系，迁移至 ESM，停止支持旧版本的 Node.js，现在必须使用 `^22.12 || >=24` 版本的 Node.js

## 📝 其他说明

<!--
补充任何 reviewer 需要知道的信息
-->
